### PR TITLE
b'error' to 'error' as shared.exe now return str instead of byte

### DIFF
--- a/qcore/test/test_xyts/test_xyts.py
+++ b/qcore/test/test_xyts/test_xyts.py
@@ -17,7 +17,7 @@ DOWNLOAD_CMD = "wget -O {} {}".format(XYTS_STORE_PATH, XYTS_DOWNLOAD_PATH)
 
 if not os.path.isfile(XYTS_STORE_PATH):
     out, err = shared.exe(DOWNLOAD_CMD, debug=False)
-    if b"failed" in err:
+    if "failed" in err:
         os.remove(XYTS_STORE_PATH)
         sys.exit("{} failted to download xyts benchmark file".format(err))
     else:

--- a/qcore/testing.py
+++ b/qcore/testing.py
@@ -34,7 +34,7 @@ def test_set_up(realizations):
         if not os.path.isdir(data_store_path):
             os.makedirs(data_store_path, exist_ok=True)
             out, err = shared.exe(download_cmd, debug=False)
-            if b"error" in err:
+            if "error" in err:
                 rmtree(data_store_path)
                 sys.exit("{} failed to retrieve test data".format(err))
             # download_via_ftp(DATA_DOWNLOAD_PATH, zip_download_path)
@@ -46,7 +46,7 @@ def test_set_up(realizations):
                 )
             out, err = shared.exe(unzip_cmd, debug=False)
             os.remove(zip_download_path)
-            if b"error" in err:
+            if "error" in err:
                 rmtree(data_store_path)
                 sys.exit("{} failed to extract data folder".format(err))
 


### PR DESCRIPTION
Change b'error' to 'error' as shared.exe now return str instead of byte