### PR TITLE
ignore error if rmtree fails during teardown

### DIFF
--- a/qcore/testing.py
+++ b/qcore/testing.py
@@ -64,4 +64,4 @@ def test_tear_down(test_data_save_dirs):
     """
     for test_data_dir in test_data_save_dirs:
         if os.path.isdir(test_data_dir):
-            rmtree(test_data_dir)
+            rmtree(test_data_dir, ignore_errors=True)


### PR DESCRIPTION
During teardown, rmtree may not correctly take place if the test is taking place within Docker accessing externally mounted data directory - Jenkins takes care of the data clean-up after docker run is over, so we can ignore if rmtree ever fails during teardown.