### PR TITLE
Added --no-data option to setup.py

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
             steps {
                 echo 'Run pytest through docker' 
 		sh """
-		docker run --rm  -v ${env.WORKSPACE}:/home/jenkins/qcore --user `id -u`:`id -g` sungeunbae/qcore-ubuntu-minimal bash -c "cd /home/jenkins/qcore;python setup.py install --user; cd qcore/test; pytest -s;"
+		docker run --rm  -v ${env.WORKSPACE}:/home/jenkins/qcore --user `id -u`:`id -g` sungeunbae/qcore-ubuntu-minimal bash -c "cd /home/jenkins/qcore;python setup.py install --no-data --user; cd qcore/test; pytest -s;"
 		"""
             }
         }

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include qcore/machine_config/*.json
+include qcore/configs/*.json

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ DATA_URL = f"{PACKAGE_URL}/releases/download/{DATA_VERSION}/{DATA_NAME}"
 
 NO_DATA_ARG = "--no-data"
 
+
 def extract_data(archive, destination):
     with tarfile.open(archive) as xz:
         xz.extractall(destination)
@@ -46,7 +47,8 @@ def prepare_data():
     if str(have_ver) != DATA_VERSION:
         sys.exit("data package issue, please contact repository maintainer")
 
-#TODO: Temporary fix to keep Jenkins testing going
+
+# TODO: Temporary fix to keep Jenkins testing going
 if NO_DATA_ARG in sys.argv:
     print(f"Skip downloading {DATA_NAME}")
     sys.argv.remove(NO_DATA_ARG)

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,14 @@ import sys
 import tarfile
 from urllib.request import urlretrieve
 
+
 PACKAGE_NAME = "qcore"
 PACKAGE_URL = f"https://github.com/ucgmsim/{PACKAGE_NAME}"
 DATA_VERSION = "1.2"
 DATA_NAME = "qcore_resources.tar.xz"
 DATA_URL = f"{PACKAGE_URL}/releases/download/{DATA_VERSION}/{DATA_NAME}"
 
+NO_DATA_ARG = "--no-data"
 
 def extract_data(archive, destination):
     with tarfile.open(archive) as xz:
@@ -44,8 +46,13 @@ def prepare_data():
     if str(have_ver) != DATA_VERSION:
         sys.exit("data package issue, please contact repository maintainer")
 
+#TODO: Temporary fix to keep Jenkins testing going
+if NO_DATA_ARG in sys.argv:
+    print(f"Skip downloading {DATA_NAME}")
+    sys.argv.remove(NO_DATA_ARG)
+else:
+    prepare_data()
 
-prepare_data()
 setup(
     name=PACKAGE_NAME,
     version="1.2",


### PR DESCRIPTION
To prevent Jenkins from downloading 1.9Gb data and filling up the disk space, added this option.

A bit hacky, but should fix the problem at hand - should be adequate as a temporary solution until we come up with a more elegant solution utilizing setuptools' feature set