### PR TITLE
Plot srf map bug

### DIFF
--- a/qcore/configs/machine_local.json
+++ b/qcore/configs/machine_local.json
@@ -1,4 +1,5 @@
 {
+    "GMT_DATA" : "/Users/sungbae/PlottingData",
     "tools_dir" : "/nesi/project/nesi00213/tools",
     "cores_per_node" : 1,
     "MAX_NODES_PER_JOB" : 1,

--- a/qcore/im.py
+++ b/qcore/im.py
@@ -139,7 +139,7 @@ class IM:
         if self.period:
             return f"{self.name}_{self.period}"
         else:
-            return self.name
+            return f"{self.name}"
 
     def pretty_im_name(self):
         """

--- a/qcore/testing.py
+++ b/qcore/testing.py
@@ -51,7 +51,7 @@ def test_set_up(realizations):
                 sys.exit("{} failed to extract data folder".format(err))
 
         else:
-            print("Benchmark data folder already exits: ", data_store_path)
+            print("Benchmark data folder already exists: ", data_store_path)
     print(test_data_save_dirs)
     # Run all tests
     return test_data_save_dirs


### PR DESCRIPTION
alphashape needs alpha parameter to be set (alpha=0 is a convex hull), but often we need a concave-hull. The question is how to determine the alpha parameter to give the best fit. Viktor originally found alpha=600 worked ok for SRF, but sometimes it doesn't return a legit Polygon object that will ensure the subsequent code works. 

This fix will, hopefully, find a reasonably good alpha value without impacting the performance too much.