### PR TITLE
changed the formats file to read comma separated z file

### DIFF
--- a/qcore/formats.py
+++ b/qcore/formats.py
@@ -101,7 +101,7 @@ def load_z_file(z_file: str):
     :return: pd.DataFrame
         station as index and columns z1p0, z2p5
     """
-    return pd.read_csv(z_file, sep="\s+", index_col=0, header=None, names=["z1p0", "z2p5"])
+    return pd.read_csv(z_file, names=["z1p0", "z2p5", "sigma"], index_col=0, skiprows=1)
 
 
 def load_station_ll_vs30(station_file: str, vs30_file: str):


### PR DESCRIPTION
I've checked this file and it looks like that the only place that this function was called was empirical db in seistech.

The proposed format going forward is keeping the comma delimited file (outputted from the VM code). - this is different to the tab/space delimited station and vs30 file.

Thoughts / changes?