### PR TITLE
Get distances multiple references

### DIFF
--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -17,34 +17,35 @@ class InputError(Exception):
     pass
 
 
-def get_distances(locations: np.ndarray, lon: float, lat: float):
-    """Calculates the distance between the array of locations and
-    the specified reference location
+def get_distances(locations: np.ndarray, lon: np.float, lat: np.float):
+    """
+    Calculates the distance between the array of locations and
+    the specified reference location / locations
 
     Parameters
     ----------
     locations : np.ndarray
         List of locations
         Shape [n_locations, 2], column format (lon, lat)
-    lon : float
-        Longitude of the reference location
-    lat
-        Latitude of the reference location
+    lon : np.float
+        Array or singular float of Longitude reference locations to compare
+    lat : np.float
+        Array or singular float of Latitude reference locations to compare
 
     Returns
     -------
     np.ndarray
-        The distances, shape [n_locations]
+        The distances, shape [n_references, n_locations]
     """
     d = (
-        np.sin(np.radians(locations[:, 1] - lat) / 2.0) ** 2
-        + np.cos(np.radians(lat))
-        * np.cos(np.radians(locations[:, 1]))
-        * np.sin(np.radians(locations[:, 0] - lon) / 2.0) ** 2
+            np.sin(np.radians(np.expand_dims(locations[:, 1], axis=1) - lat) / 2.0) ** 2
+            + np.cos(np.radians(lat))
+            * np.cos(np.radians(np.expand_dims(locations[:, 1], axis=1)))
+            * np.sin(np.radians(np.expand_dims(locations[:, 0], axis=1) - lon) / 2.0) ** 2
     )
     d = R_EARTH * 2.0 * np.arctan2(np.sqrt(d), np.sqrt(1 - d))
 
-    return d
+    return d.T
 
 
 def closest_location(locations, lon, lat):

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -7,7 +7,6 @@ from math import sin, asin, cos, acos, atan, atan2, degrees, radians, sqrt, pi
 from warnings import warn
 
 import numpy as np
-from numba import njit
 
 from qcore.binary_version import get_unversioned_bin
 
@@ -23,7 +22,6 @@ def get_distances(locations: np.ndarray, lon: float, lat: float):
     Calculates the distance between the array of locations and
     the specified reference location
     Does the same as get_multiple_distances except for a single reference location
-    Note: Is not within the same function due to numba and type unification
 
     Parameters
     ----------
@@ -43,7 +41,6 @@ def get_distances(locations: np.ndarray, lon: float, lat: float):
     return get_multiple_distances(locations, lon, lat)[0]
 
 
-@njit
 def get_multiple_distances(locations: np.ndarray, lon: np.float, lat: np.float):
     """
     Calculates the distance between the array of locations and

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -7,6 +7,7 @@ from math import sin, asin, cos, acos, atan, atan2, degrees, radians, sqrt, pi
 from warnings import warn
 
 import numpy as np
+from numba import njit
 
 from qcore.binary_version import get_unversioned_bin
 
@@ -17,10 +18,36 @@ class InputError(Exception):
     pass
 
 
-def get_distances(locations: np.ndarray, lon: np.float, lat: np.float):
+def get_distances(locations: np.ndarray, lon: float, lat: float):
     """
     Calculates the distance between the array of locations and
-    the specified reference location / locations
+    the specified reference location
+    Does the same as get_multiple_distances except for a single reference location
+    Note: Is not within the same function due to numba and type unification
+
+    Parameters
+    ----------
+    locations : np.ndarray
+        List of locations
+        Shape [n_locations, 2], column format (lon, lat)
+    lon : float
+        Singular float of a Longitude reference location to compare
+    lat : float
+        Singular float of a Latitude reference locations to compare
+
+    Returns
+    -------
+    np.ndarray
+        The distances, shape [n_locations]
+    """
+    return get_multiple_distances(locations, lon, lat)[0]
+
+
+@njit
+def get_multiple_distances(locations: np.ndarray, lon: np.float, lat: np.float):
+    """
+    Calculates the distance between the array of locations and
+    the specified reference locations
 
     Parameters
     ----------
@@ -44,7 +71,6 @@ def get_distances(locations: np.ndarray, lon: np.float, lat: np.float):
         * np.sin(np.radians(np.expand_dims(locations[:, 0], axis=1) - lon) / 2.0) ** 2
     )
     d = R_EARTH * 2.0 * np.arctan2(np.sqrt(d), np.sqrt(1 - d))
-
     return d.T
 
 

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -17,34 +17,11 @@ class InputError(Exception):
     pass
 
 
-def get_distances(locations: np.ndarray, lon: float, lat: float):
+def get_distances(locations: np.ndarray, lon: np.float, lat: np.float):
     """
     Calculates the distance between the array of locations and
     the specified reference location
     Does the same as get_multiple_distances except for a single reference location
-
-    Parameters
-    ----------
-    locations : np.ndarray
-        List of locations
-        Shape [n_locations, 2], column format (lon, lat)
-    lon : float
-        Singular float of a Longitude reference location to compare
-    lat : float
-        Singular float of a Latitude reference locations to compare
-
-    Returns
-    -------
-    np.ndarray
-        The distances, shape [n_locations]
-    """
-    return get_multiple_distances(locations, lon, lat)[0]
-
-
-def get_multiple_distances(locations: np.ndarray, lon: np.float, lat: np.float):
-    """
-    Calculates the distance between the array of locations and
-    the specified reference locations
 
     Parameters
     ----------
@@ -59,7 +36,8 @@ def get_multiple_distances(locations: np.ndarray, lon: np.float, lat: np.float):
     Returns
     -------
     np.ndarray
-        The distances, shape [n_references, n_locations]
+        The distances, shape [n_locations] or shape [n_references, n_locations]
+        based on the input lon, lat values being a single float or array
     """
     d = (
         np.sin(np.radians(np.expand_dims(locations[:, 1], axis=1) - lat) / 2.0) ** 2
@@ -68,7 +46,7 @@ def get_multiple_distances(locations: np.ndarray, lon: np.float, lat: np.float):
         * np.sin(np.radians(np.expand_dims(locations[:, 0], axis=1) - lon) / 2.0) ** 2
     )
     d = R_EARTH * 2.0 * np.arctan2(np.sqrt(d), np.sqrt(1 - d))
-    return d.T
+    return d.T[0] if d.shape[1] == 1 else d.T
 
 
 def closest_location(locations, lon, lat):

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -45,8 +45,8 @@ def get_distances(locations: np.ndarray, lon: np.float, lat: np.float):
         * np.cos(np.radians(np.expand_dims(locations[:, 1], axis=1)))
         * np.sin(np.radians(np.expand_dims(locations[:, 0], axis=1) - lon) / 2.0) ** 2
     )
-    d = R_EARTH * 2.0 * np.arctan2(np.sqrt(d), np.sqrt(1 - d))
-    return d.T[0] if d.shape[1] == 1 else d.T
+    d = (R_EARTH * 2.0 * np.arctan2(np.sqrt(d), np.sqrt(1 - d))).T
+    return d[0] if d.shape[1] == 1 else d
 
 
 def closest_location(locations, lon, lat):

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -5,6 +5,7 @@ Various tools which may be needed in various processes.
 from subprocess import Popen, PIPE
 from math import sin, asin, cos, acos, atan, atan2, degrees, radians, sqrt, pi
 from warnings import warn
+from typing import Union
 
 import numpy as np
 
@@ -17,20 +18,19 @@ class InputError(Exception):
     pass
 
 
-def get_distances(locations: np.ndarray, lon: np.float, lat: np.float):
+def get_distances(locations: np.ndarray, lon: Union[float, np.ndarray], lat: Union[float, np.ndarray]):
     """
     Calculates the distance between the array of locations and
-    the specified reference location
-    Does the same as get_multiple_distances except for a single reference location
+    the specified reference location / locations
 
     Parameters
     ----------
     locations : np.ndarray
         List of locations
         Shape [n_locations, 2], column format (lon, lat)
-    lon : np.float
+    lon : Union[float, np.ndarray]
         Array or singular float of Longitude reference locations to compare
-    lat : np.float
+    lat : Union[float, np.ndarray]
         Array or singular float of Latitude reference locations to compare
 
     Returns

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -38,10 +38,10 @@ def get_distances(locations: np.ndarray, lon: np.float, lat: np.float):
         The distances, shape [n_references, n_locations]
     """
     d = (
-            np.sin(np.radians(np.expand_dims(locations[:, 1], axis=1) - lat) / 2.0) ** 2
-            + np.cos(np.radians(lat))
-            * np.cos(np.radians(np.expand_dims(locations[:, 1], axis=1)))
-            * np.sin(np.radians(np.expand_dims(locations[:, 0], axis=1) - lon) / 2.0) ** 2
+        np.sin(np.radians(np.expand_dims(locations[:, 1], axis=1) - lat) / 2.0) ** 2
+        + np.cos(np.radians(lat))
+        * np.cos(np.radians(np.expand_dims(locations[:, 1], axis=1)))
+        * np.sin(np.radians(np.expand_dims(locations[:, 0], axis=1) - lon) / 2.0) ** 2
     )
     d = R_EARTH * 2.0 * np.arctan2(np.sqrt(d), np.sqrt(1 - d))
 


### PR DESCRIPTION
Allows for multiple reference lat and lon values to be used in the get distances calculation.
Ensured output was the same shape for using single float values too and works with numba.njit