### PR TITLE
Adding WCT as a Status Enum

### DIFF
--- a/qcore/constants.py
+++ b/qcore/constants.py
@@ -274,7 +274,7 @@ class Status(ExtendedStrEnum):
     running = 3, "running"
     unknown = 4, "unknown"
     completed = 5, "completed"
-    WCT = 6, "WCT"
+    killed_WCT = 6, "killed_WCT"
     failed = 7, "failed"
 
 

--- a/qcore/constants.py
+++ b/qcore/constants.py
@@ -274,7 +274,8 @@ class Status(ExtendedStrEnum):
     running = 3, "running"
     unknown = 4, "unknown"
     completed = 5, "completed"
-    failed = 6, "failed"
+    WCT = 6, "WCT"
+    failed = 7, "failed"
 
 
 class RootParams(Enum):


### PR DESCRIPTION
As part of the workflow metadata refactor, the WCT needed to be added to the Status Enum