### PR TITLE
Hotfix for GMHazard API tests

### DIFF
--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -55,7 +55,7 @@ def closest_location(locations, lon, lat):
     """
     d = get_distances(locations, lon, lat)
     i = np.argmin(d)
-    # breakpoint()
+
     return i, d[i]
 
 

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -46,7 +46,7 @@ def get_distances(locations: np.ndarray, lon: Union[float, np.ndarray], lat: Uni
         * np.sin(np.radians(np.expand_dims(locations[:, 0], axis=1) - lon) / 2.0) ** 2
     )
     d = (R_EARTH * 2.0 * np.arctan2(np.sqrt(d), np.sqrt(1 - d))).T
-    return d[0] if d.shape[1] == 1 else d
+    return d[0] if d.shape[0] == 1 else d
 
 
 def closest_location(locations, lon, lat):
@@ -55,7 +55,7 @@ def closest_location(locations, lon, lat):
     """
     d = get_distances(locations, lon, lat)
     i = np.argmin(d)
-
+    # breakpoint()
     return i, d[i]
 
 


### PR DESCRIPTION
# HOTFIX qcore for GMHazard API tests

`d.shape` is something like `(1, 122)` so we need to check the 0 index instad.

## Examples
```python
"/tmp/core_api_test_20220404_0500028ic4suox/gmhazard/calculation/gmhazard_calc/gmhazard_calc/nz_code/nzta_2018/nzta.py", line 180, in __location_lookup
   idx, dist = geo.closest_location(
 File "/tmp/core_api_test_20220404_0500028ic4suox/qcore/qcore/geo.py", line 59, in closest_location
   return i, d[i]
IndexError: index 93 is out of bounds for axis 0 with size 1
```
```python
"/tmp/core_api_test_20220404_0500028ic4suox/gmhazard/calculation/gmhazard_calc/gmhazard_calc/nz_code/nzta_2018/nzta.py", line 180, in __location_lookup
   idx, dist = geo.closest_location(
 File "/tmp/core_api_test_20220404_0500028ic4suox/qcore/qcore/geo.py", line 59, in closest_location
   return i, d[i]
IndexError: index 93 is out of bounds for axis 0 with size 1
```
