### PR TITLE
get_fault_from_realisation() fix for a fault name containing an underscore

### DIFF
--- a/qcore/simulation_structure.py
+++ b/qcore/simulation_structure.py
@@ -10,7 +10,6 @@ def get_fault_from_realisation(realisation):
     realisation = os.path.basename(realisation)  # if realisation is a fullpath
     return realisation.rsplit("_REL",1)[0]
 
-
 def get_realisation_name(fault_name, rel_no):
     return "{}_REL{:0>2}".format(fault_name, rel_no)
 

--- a/qcore/simulation_structure.py
+++ b/qcore/simulation_structure.py
@@ -8,7 +8,7 @@ import qcore.constants as const
 
 def get_fault_from_realisation(realisation):
     realisation = os.path.basename(realisation)  # if realisation is a fullpath
-    return realisation.rsplit("_REL")[0]
+    return realisation.rsplit("_REL",1)[0]
 
 
 def get_realisation_name(fault_name, rel_no):

--- a/qcore/simulation_structure.py
+++ b/qcore/simulation_structure.py
@@ -8,7 +8,7 @@ import qcore.constants as const
 
 def get_fault_from_realisation(realisation):
     realisation = os.path.basename(realisation)  # if realisation is a fullpath
-    return realisation.split("_REL")[0]
+    return realisation.rsplit("_REL")[0]
 
 
 def get_realisation_name(fault_name, rel_no):


### PR DESCRIPTION
If a fault name contains an underscore, get_fault_from_realisaton can split the fault name and realisation part incorrectly.
For example, get_fault_from_realisaton_fix(XXXX_YYY_REL01) should return XXXX_YYY, not XXXX.