### PR TITLE
updated to short form for Skarlatoudis

### DIFF
--- a/qcore/uncertainties/mag_scaling.py
+++ b/qcore/uncertainties/mag_scaling.py
@@ -210,11 +210,11 @@ def a_to_mw_hanksbakun(a):
 
 
 def a_to_mw_skarlatoudis(a):
-    return np.log10(a) - (np.log10(1.77 * np.power(10.0, -10)) + 6.03)
+    return np.log10(a) + 3.722
 
 
 def mw_to_a_skarlatoudis(mw):
-    return 1.77 * 10 ** -10 * (10 ** ((3 * (mw + 6.03)) / 2)) ** (2 / 3)
+    return 10**(mw - 3.722)
 
 
 def lw_to_mw_stirling(l, w):


### PR DESCRIPTION
mag_scaling.a_to_mw_skarlatoudis(10e4)
Out[6]: 8.722026733638192

numpy.log10(10e4) + 3.722
Out[11]: 8.722

mag_scaling.mw_to_a_skarlatoudis(8.0)
Out[13]: 18965.891702705652

10**(8.0 - 3.722)
Out[15]: 18967.059212111482

Same to 4s.f.