### PR TITLE
Support for old non_REL realisation names

### DIFF
--- a/qcore/simulation_structure.py
+++ b/qcore/simulation_structure.py
@@ -8,7 +8,10 @@ import qcore.constants as const
 
 def get_fault_from_realisation(realisation):
     realisation = os.path.basename(realisation)  # if realisation is a fullpath
-    return realisation.rsplit("_REL",1)[0]
+    if "_REL" in realisation: # newer realisation name 
+        return realisation.rsplit("_REL",1)[0]
+    else:
+        return realisation.split("_",1)[0] # old realsations eg. Hossack_HYP01-501_S1244 -> Hossack
 
 def get_realisation_name(fault_name, rel_no):
     return "{}_REL{:0>2}".format(fault_name, rel_no)


### PR DESCRIPTION
Related to an old PR https://github.com/ucgmsim/qcore/pull/270

An old realisation name not including "_REL" can not correctly return a fault name and this fix resolves it.
eg. Hossack_HYP01-501_S1244 -> Hossack