### PR TITLE
Add in function to confine job parameters to those of the machine bei…

### DIFF
--- a/qcore/config.py
+++ b/qcore/config.py
@@ -58,6 +58,7 @@ class ConfigKeys(Enum):
     cores_per_node = auto()
     MAX_JOB_WCT = auto()
     MAX_NODES_PER_JOB = auto()
+    MAX_CH_PER_JOB = auto()
 
 
 host, host_config_path = determine_machine_config()

--- a/qcore/configs/machine_local.json
+++ b/qcore/configs/machine_local.json
@@ -2,5 +2,6 @@
     "tools_dir" : "/nesi/project/nesi00213/tools",
     "cores_per_node" : 1,
     "MAX_NODES_PER_JOB" : 1,
-    "MAX_JOB_WCT" : 1000
+    "MAX_JOB_WCT" : 1000,
+    "MAX_CH_PER_JOB": Infinity
 }

--- a/qcore/configs/machine_mahuika.json
+++ b/qcore/configs/machine_mahuika.json
@@ -1,6 +1,7 @@
 {
     "tools_dir" : "/nesi/project/nesi00213/opt/mahuika/hybrid_sim_tools/",
     "cores_per_node" : 36,
-    "MAX_NODES_PER_JOB" : 66,
-    "MAX_JOB_WCT" : 24
+    "MAX_NODES_PER_JOB" : 8,
+    "MAX_JOB_WCT" : 24,
+    "MAX_CH_PER_JOB": 20000
 }

--- a/qcore/configs/machine_maui.json
+++ b/qcore/configs/machine_maui.json
@@ -3,5 +3,6 @@
     "OpenSees" : "/nesi/project/nesi00213/opt/maui/software/OpenSees/3.2.0-CrayGNU-19.04/OpenSees",
     "cores_per_node" : 40,
     "MAX_NODES_PER_JOB" : 66,
-    "MAX_JOB_WCT" : 24
+    "MAX_JOB_WCT" : 24,
+    "MAX_CH_PER_JOB": 48000
 }

--- a/qcore/configs/machine_maui.json
+++ b/qcore/configs/machine_maui.json
@@ -2,7 +2,7 @@
     "tools_dir" : "/nesi/project/nesi00213/opt/maui/hybrid_sim_tools/",
     "OpenSees" : "/nesi/project/nesi00213/opt/maui/software/OpenSees/3.2.0-CrayGNU-19.04/OpenSees",
     "cores_per_node" : 40,
-    "MAX_NODES_PER_JOB" : 66,
+    "MAX_NODES_PER_JOB" : 240,
     "MAX_JOB_WCT" : 24,
     "MAX_CH_PER_JOB": 48000
 }

--- a/qcore/configs/machine_nurion.json
+++ b/qcore/configs/machine_nurion.json
@@ -2,5 +2,6 @@
     "tools_dir" : "/home01/x2319a02/gmsim/opt/nurion/hybrid_sim_tools/current",
     "cores_per_node": 64,
     "MAX_NODES_PER_JOB" : 4970,
-    "MAX_JOB_WCT" : 48
+    "MAX_JOB_WCT" : 48,
+    "MAX_CH_PER_JOB": Infinity
 }

--- a/qcore/configs/machine_nurion.json
+++ b/qcore/configs/machine_nurion.json
@@ -1,5 +1,5 @@
 {
-    "tools_dir" : "/home01/x2319a02/gmsim/opt/nurion/hybrid_sim_tools/current",
+    "tools_dir" : "/home01/x2568a02/gmsim/opt/nurion/hybrid_sim_tools/current",
     "cores_per_node": 64,
     "MAX_NODES_PER_JOB" : 4970,
     "MAX_JOB_WCT" : 48,

--- a/qcore/configs/machine_stampede2.json
+++ b/qcore/configs/machine_stampede2.json
@@ -1,6 +1,7 @@
 {
-  "tools_dir": "/work/06833/sungbae/stampede2/tools",
-  "cores_per_node": 64,
-  "MAX_NODES_PER_JOB" : 256,
-  "MAX_JOB_WCT" : 48
+    "tools_dir": "/work/06833/sungbae/stampede2/tools",
+    "cores_per_node": 64,
+    "MAX_NODES_PER_JOB" : 256,
+    "MAX_JOB_WCT" : 48,
+    "MAX_CH_PER_JOB": Infinity
 }


### PR DESCRIPTION
…ng run on. (Assumes large for mahuika)

Add max core hours to machine config files. Infinity used where no better information available. Add this funcitonality to the submit scripts
Remove set_wct as this function just printed what is happening to the logs and returned the formatted string WCT