### PR TITLE
Adding memory per node

### DIFF
--- a/qcore/config.py
+++ b/qcore/config.py
@@ -55,7 +55,7 @@ def get_machine_config(hostname=node(), config_path=None):
 class ConfigKeys(Enum):
     tools_dir = auto()
     cores_per_node = auto()
-    memory_per_node = auto()
+    memory_per_core = auto()
     MAX_JOB_WCT = auto()
     MAX_NODES_PER_JOB = auto()
     MAX_CH_PER_JOB = auto()

--- a/qcore/config.py
+++ b/qcore/config.py
@@ -20,7 +20,6 @@ def determine_machine_config(hostname=node()):
     Determines the machine name eg: nodes ni0002 and maui01 belong to maui.
     :return: machine name, config file
     """
-
     if (hostname.startswith("ni") and len(hostname) == 8) or hostname.startswith(
         __KnownMachines.maui.name
     ):
@@ -56,6 +55,7 @@ def get_machine_config(hostname=node(), config_path=None):
 class ConfigKeys(Enum):
     tools_dir = auto()
     cores_per_node = auto()
+    memory_per_node = auto()
     MAX_JOB_WCT = auto()
     MAX_NODES_PER_JOB = auto()
     MAX_CH_PER_JOB = auto()

--- a/qcore/configs/machine_local.json
+++ b/qcore/configs/machine_local.json
@@ -1,6 +1,7 @@
 {
     "tools_dir" : "/nesi/project/nesi00213/tools",
     "cores_per_node" : 1,
+    "memory_per_node" : 1,
     "MAX_NODES_PER_JOB" : 1,
     "MAX_JOB_WCT" : 1000,
     "MAX_CH_PER_JOB": Infinity

--- a/qcore/configs/machine_local.json
+++ b/qcore/configs/machine_local.json
@@ -1,7 +1,7 @@
 {
     "tools_dir" : "/nesi/project/nesi00213/tools",
     "cores_per_node" : 1,
-    "memory_per_node" : 1,
+    "memory_per_core" : 1,
     "MAX_NODES_PER_JOB" : 1,
     "MAX_JOB_WCT" : 1000,
     "MAX_CH_PER_JOB": Infinity

--- a/qcore/configs/machine_mahuika.json
+++ b/qcore/configs/machine_mahuika.json
@@ -1,7 +1,7 @@
 {
     "tools_dir" : "/nesi/project/nesi00213/opt/mahuika/hybrid_sim_tools/",
     "cores_per_node" : 36,
-    "memory_per_node" : 1.5,
+    "memory_per_core" : 1.5,
     "MAX_NODES_PER_JOB" : 8,
     "MAX_JOB_WCT" : 24,
     "MAX_CH_PER_JOB": 20000

--- a/qcore/configs/machine_mahuika.json
+++ b/qcore/configs/machine_mahuika.json
@@ -1,6 +1,7 @@
 {
     "tools_dir" : "/nesi/project/nesi00213/opt/mahuika/hybrid_sim_tools/",
     "cores_per_node" : 36,
+    "memory_per_node" : 1.5,
     "MAX_NODES_PER_JOB" : 8,
     "MAX_JOB_WCT" : 24,
     "MAX_CH_PER_JOB": 20000

--- a/qcore/configs/machine_maui.json
+++ b/qcore/configs/machine_maui.json
@@ -2,7 +2,7 @@
     "tools_dir" : "/nesi/project/nesi00213/opt/maui/hybrid_sim_tools/",
     "OpenSees" : "/nesi/project/nesi00213/opt/maui/software/OpenSees/3.2.0-CrayGNU-19.04/OpenSees",
     "cores_per_node" : 40,
-    "memory_per_node" : 1.5,
+    "memory_per_core" : 1.5,
     "MAX_NODES_PER_JOB" : 240,
     "MAX_JOB_WCT" : 24,
     "MAX_CH_PER_JOB": 48000

--- a/qcore/configs/machine_maui.json
+++ b/qcore/configs/machine_maui.json
@@ -2,6 +2,7 @@
     "tools_dir" : "/nesi/project/nesi00213/opt/maui/hybrid_sim_tools/",
     "OpenSees" : "/nesi/project/nesi00213/opt/maui/software/OpenSees/3.2.0-CrayGNU-19.04/OpenSees",
     "cores_per_node" : 40,
+    "memory_per_node" : 1.5,
     "MAX_NODES_PER_JOB" : 240,
     "MAX_JOB_WCT" : 24,
     "MAX_CH_PER_JOB": 48000

--- a/qcore/configs/machine_nurion.json
+++ b/qcore/configs/machine_nurion.json
@@ -1,7 +1,7 @@
 {
     "tools_dir" : "/home01/x2568a02/gmsim/opt/nurion/hybrid_sim_tools/current",
     "cores_per_node": 64,
-    "memory_per_node" : 1.4,
+    "memory_per_core" : 1.4,
     "MAX_NODES_PER_JOB" : 4970,
     "MAX_JOB_WCT" : 48,
     "MAX_CH_PER_JOB": Infinity

--- a/qcore/configs/machine_nurion.json
+++ b/qcore/configs/machine_nurion.json
@@ -1,6 +1,7 @@
 {
     "tools_dir" : "/home01/x2568a02/gmsim/opt/nurion/hybrid_sim_tools/current",
     "cores_per_node": 64,
+    "memory_per_node" : 1.4,
     "MAX_NODES_PER_JOB" : 4970,
     "MAX_JOB_WCT" : 48,
     "MAX_CH_PER_JOB": Infinity

--- a/qcore/configs/machine_stampede2.json
+++ b/qcore/configs/machine_stampede2.json
@@ -1,6 +1,7 @@
 {
     "tools_dir": "/work/06833/sungbae/stampede2/tools",
     "cores_per_node": 64,
+    "memory_per_node" : 1.4,
     "MAX_NODES_PER_JOB" : 256,
     "MAX_JOB_WCT" : 48,
     "MAX_CH_PER_JOB": Infinity

--- a/qcore/configs/machine_stampede2.json
+++ b/qcore/configs/machine_stampede2.json
@@ -1,7 +1,7 @@
 {
     "tools_dir": "/work/06833/sungbae/stampede2/tools",
     "cores_per_node": 64,
-    "memory_per_node" : 1.4,
+    "memory_per_core" : 1.4,
     "MAX_NODES_PER_JOB" : 256,
     "MAX_JOB_WCT" : 48,
     "MAX_CH_PER_JOB": Infinity


### PR DESCRIPTION
Adding the memory per core for each of the machines. Used for estimating the minimum amount of cores needed to allow for enough memory for LF.