### PR TITLE
Untied Empirical from rrup

### DIFF
--- a/qcore/constants.py
+++ b/qcore/constants.py
@@ -335,7 +335,7 @@ class ProcessType(ExtendedStrEnum):
         None,
         False,
         None,
-        ([(rrup, "REL")],),
+        ([(INSTALL_REALISATION, "REL"), (INSTALL_FAULT, "MEDIAN")],),
     )
 
     Verification = (


### PR DESCRIPTION
New empirical calculation calculates rrups on-the-fly and does it very fast, making it no longer require rrup as a pre-requisite.
https://github.com/ucgmsim/Empirical_Engine/pull/108

Empirical calculation now can take the place of rrup calculation in the overall pipeline
https://wiki.canterbury.ac.nz/display/QuakeCore/Automated+workflow+pipelines

We can deprecate rrup step eventually, but let's keep it out of this PR. 
(Even if we do so in the future, we should never use its integer id 8 for other step, which can upset an existing workflow DB created by an old version of workflow code)
