### PR TITLE
Add functions to compute the closest points between planes in 3D

### DIFF
--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -901,10 +901,12 @@ def projective_span(p: np.ndarray, q: np.ndarray, r: np.ndarray) -> np.ndarray:
     return ns / c
 
 
-def plane_from_three_points(p: np.ndarray, q: np.ndarray, r: np.ndarray):
+def plane_from_three_points(p: np.ndarray, q: np.ndarray, r: np.ndarray) -> np.ndarray:
     """Find the plane spanning three points.
 
     Returns the coefficient vector of the affine plane spanning three points.
+    Note this is distinct from projective_span in that p, q, and r are three
+    points in R^3.
 
     Parameters
     ----------
@@ -914,6 +916,11 @@ def plane_from_three_points(p: np.ndarray, q: np.ndarray, r: np.ndarray):
         a point on the plane.
     r : np.ndarray
         a point on the plane.
+
+    Returns
+    -------
+    np.ndarray
+        The dual coordinates of the plane spanning p, q, and r.
 
     Examples
     --------

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -854,7 +854,7 @@ def homogenise_point(p: np.ndarray) -> np.ndarray:
     array([1,0,0,1])
     """
 
-    return np.concatenate((p, np.array([1])))
+    return np.append(p, 1)
 
 
 def projective_span(p: np.ndarray, q: np.ndarray, r: np.ndarray) -> np.ndarray:

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -904,7 +904,7 @@ def projective_span(p: np.ndarray, q: np.ndarray, r: np.ndarray) -> np.ndarray:
     #
     # NOTE: This choice to normalise by the last coordinate is arbitrary. Any
     # method of normalisation would work.
-    null_space = null_space.reshape((1, -1))[0]
+    null_space = null_space.ravel()
     c = next(x for x in reversed(null_space) if not np.isclose(x, 0))
     return null_space / c
 

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -3,6 +3,7 @@ Various tools which may be needed in various processes.
 """
 
 import functools
+import itertools
 from math import acos, asin, atan, atan2, cos, degrees, pi, radians, sin, sqrt
 from subprocess import PIPE, Popen
 from typing import Tuple, Union
@@ -1095,3 +1096,33 @@ def closest_points_between_planes(
 
     solution = result.x
     return (solution[:3], solution[3:])
+
+
+def closest_points_between_plane_sequences(
+    sequence1_planes: np.ndarray, sequence2_planes: np.ndarray
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Find the closest points between two sequences of planes
+
+    Parameters
+    ----------
+    sequence1_planes : np.ndarray
+        A sequence of planes (tensor of shape (n x 4 x 3)).
+    sequence2_planes : np.ndarray
+        A sequence of planes (tensor of shape (n x 4 x 3)).
+
+    Returns
+    -------
+    (np.ndarray, np.ndarray)
+        Points (p, q) minimising ||p - q|| such that p lies on sequence1_planes and
+        q lies on sequence2_planes.
+
+    """
+    return min(
+        (
+            closest_points_between_planes(p1, p2)
+            for (p1, p2) in itertools.product(sequence1_planes, sequence2_planes)
+        ),
+        key=lambda pq: sp.spatial.distance.cdist(
+            pq[0].reshape((1, 3)), pq[1].reshape((1, 3)), metric="sqeuclidean"
+        ),
+    )

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -2,14 +2,14 @@
 Various tools which may be needed in various processes.
 """
 
-from subprocess import Popen, PIPE
-from math import sin, asin, cos, acos, atan, atan2, degrees, radians, sqrt, pi
-from warnings import warn
+import functools
+from math import acos, asin, atan, atan2, cos, degrees, pi, radians, sin, sqrt
+from subprocess import PIPE, Popen
 from typing import Union
+from warnings import warn
 
 import numpy as np
 import scipy as sp
-import functools
 
 from qcore.binary_version import get_unversioned_bin
 

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -1074,7 +1074,9 @@ def closest_points_between_planes(
     def distance(x):
         # x is a numpy array 6-tuple containing the position of the points p and q.
         # returns ||p - q||^2
-        return np.sum(np.square(x[:3] - x[3:]))
+        return sp.spatial.distance.cdist(
+            x[:3].reshape((1, 3)), x[3:].reshape((1, 3)), metric="sqeuclidean"
+        )
 
     # Our initial guess is just the centroid of each plane.
     x0 = [*p1_centroid, *p2_centroid]

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -888,14 +888,19 @@ def projective_span(p: np.ndarray, q: np.ndarray, r: np.ndarray) -> np.ndarray:
     """
     M = np.vstack([p, q, r])
     null_space = sp.linalg.null_space(M)
-    # If the null space does not have dimension 1 then the points supplied do
-    # not span a unique plane. This could happen if the points supplied are
-    # collinear.
+    # The null space of M describes the space of all dual coordinates x such
+    # that x * p == 0, x * q == 0, and x * r == 0. Such coordinates, if p, q,
+    # and r are not collinear, should be unique up to scalar multiples. In that
+    # case, the null_space has rank 1 to represent these scalar multiples.
+    # Hence, if null_space does not have rank 1 (checked via shape[1]), the
+    # points supplied cannot be contained within a unique plane.
     if null_space.shape[1] != 1:
         raise ValueError("Points supplied do not span a plane.")
-    # Otherwise we just rescale the homogenous vector. It is now mathematically
-    # impossible that the vector is zero, so we can safely assume that c != 0 in the following code.
-    # We normalise by the last non-zero coordinate of the point.
+    # As previously discussed, the dual coordinates for any plane are not
+    # unique. The plane x = 0 could be given dual coordinates (1, 0, 0, 0), or
+    # equivalently (2, 0, 0, 0). We need to choose one of these coordinates
+    # deterministically. This is usually done by rescaling the coordinates such
+    # that the last non-zero coordinate is one (a process called normalisation).
     null_space = null_space.reshape((1, -1))[0]
     c = next(x for x in reversed(null_space) if not np.isclose(x, 0))
     return null_space / c

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -852,7 +852,7 @@ def homogenise_point(p: np.ndarray) -> np.ndarray:
     array([1,0,0,1])
     """
 
-    return np.concatenate((p, [1]))
+    return np.concatenate((p, np.array([1])))
 
 
 def projective_span(p: np.ndarray, q: np.ndarray, r: np.ndarray) -> np.ndarray:

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -887,18 +887,18 @@ def projective_span(p: np.ndarray, q: np.ndarray, r: np.ndarray) -> np.ndarray:
     ValueError: Points supplied do not span a plane. # NOTE: these points lie on the line x = y.
     """
     M = np.vstack([p, q, r])
-    ns = sp.linalg.null_space(M)
+    null_space = sp.linalg.null_space(M)
     # If the null space does not have dimension 1 then the points supplied do
     # not span a unique plane. This could happen if the points supplied are
     # collinear.
-    if ns.shape[1] != 1:
+    if null_space.shape[1] != 1:
         raise ValueError("Points supplied do not span a plane.")
     # Otherwise we just rescale the homogenous vector. It is now mathematically
     # impossible that the vector is zero, so we can safely assume that c != 0 in the following code.
     # We normalise by the last non-zero coordinate of the point.
-    ns = ns.reshape((1, -1))[0]
-    c = next(x for x in reversed(ns) if not np.isclose(x, 0))
-    return ns / c
+    null_space = null_space.reshape((1, -1))[0]
+    c = next(x for x in reversed(null_space) if not np.isclose(x, 0))
+    return null_space / c
 
 
 def plane_from_three_points(p: np.ndarray, q: np.ndarray, r: np.ndarray) -> np.ndarray:

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -5,7 +5,7 @@ Various tools which may be needed in various processes.
 import functools
 from math import acos, asin, atan, atan2, cos, degrees, pi, radians, sin, sqrt
 from subprocess import PIPE, Popen
-from typing import Union
+from typing import Tuple, Union
 from warnings import warn
 
 import numpy as np
@@ -973,7 +973,7 @@ def orthogonal_plane(pi: np.ndarray, p: np.ndarray, q: np.ndarray) -> np.ndarray
 
 def closest_points_between_planes(
     p1_corners: np.ndarray, p2_corners: np.ndarray
-) -> (np.ndarray, np.ndarray):
+) -> Tuple[np.ndarray, np.ndarray]:
     """Compute the closest points between two finite planes.
 
     This function solves the closest point problem by phrasing it as a

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -901,6 +901,9 @@ def projective_span(p: np.ndarray, q: np.ndarray, r: np.ndarray) -> np.ndarray:
     # equivalently (2, 0, 0, 0). We need to choose one of these coordinates
     # deterministically. This is usually done by rescaling the coordinates such
     # that the last non-zero coordinate is one (a process called normalisation).
+    #
+    # NOTE: This choice to normalise by the last coordinate is arbitrary. Any
+    # method of normalisation would work.
     null_space = null_space.reshape((1, -1))[0]
     c = next(x for x in reversed(null_space) if not np.isclose(x, 0))
     return null_space / c

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -833,9 +833,10 @@ def compute_intermediate_latitudes(lon_lat1, lon_lat2, lon_in):
 
 
 def homogenise_point(p: np.ndarray) -> np.ndarray:
-    """Express a point in homogenous coordinates
+    """Express a point in homogenous coordinates.
 
-    Given a point p in R^3 return the affine point in PG(3, R) associated with p.
+    Given a point p in R^3 return the affine point in PG(3, R) associated with p. Informally, it maps
+    (x, y, z) -> (x, y, z, 1).
 
     Parameters
     ----------
@@ -857,16 +858,16 @@ def homogenise_point(p: np.ndarray) -> np.ndarray:
 
 
 def projective_span(p: np.ndarray, q: np.ndarray, r: np.ndarray) -> np.ndarray:
-    """Find the projective plane spanned by p, q, and r
+    """Find the projective plane spanned by p, q, and r.
 
     Parameters
     ----------
     p : np.ndarray
-        The homogenous coordinates of p
+        The homogenous coordinates of p.
     q : np.ndarray
-        The homogenous coordinates of q
+        The homogenous coordinates of q.
     r : np.ndarray
-        The homogenous coordinates of r
+        The homogenous coordinates of r.
 
     Returns
     -------
@@ -901,7 +902,7 @@ def projective_span(p: np.ndarray, q: np.ndarray, r: np.ndarray) -> np.ndarray:
 
 
 def plane_from_three_points(p: np.ndarray, q: np.ndarray, r: np.ndarray):
-    """Find the plane spanning three points
+    """Find the plane spanning three points.
 
     Returns the coefficient vector of the affine plane spanning three points.
 
@@ -928,7 +929,7 @@ def plane_from_three_points(p: np.ndarray, q: np.ndarray, r: np.ndarray):
 
 
 def orthogonal_plane(pi: np.ndarray, p: np.ndarray, q: np.ndarray) -> np.ndarray:
-    """Find the orthogonal plane to pi through p and q
+    """Find the orthogonal plane to pi through p and q.
 
     Given two points p and q, find the unique orthogonal plane that meets pi at
     p and q.
@@ -936,16 +937,16 @@ def orthogonal_plane(pi: np.ndarray, p: np.ndarray, q: np.ndarray) -> np.ndarray
     Parameters
     ----------
     pi : np.ndarray
-        Dual coordinates of the plane
+        Dual coordinates of the plane.
     p : np.ndarray
-        Coordinates of the point p
+        Coordinates of the point p.
     q : np.ndarray
         Coordinates of the point q
 
     Returns
     -------
     np.ndarray
-        The dual coordinates of the homogenous plane
+        The dual coordinates of the homogenous plane.
 
     Examples
     --------
@@ -1020,7 +1021,7 @@ def closest_points_between_planes(
         for i in range(len(p1_corners))
     ]
 
-    # The dual coordinates of a plane are defined up to scalar multiples. Here
+    # The dual coordinates of a plane are defined up to scalar multiples. Here we
     # scale the coordinates to ensure that the normal vectors point towards the
     # centre.
     #
@@ -1035,7 +1036,7 @@ def closest_points_between_planes(
     #   | /   c    /
     #    x--------x
     #
-    # Where p1 is the plane, p1' the plane orthogonal to p1, norm the normal vector pointing towards c, the centroid.
+    # Where p1 is the plane, p1' the plane orthogonal to p1, and norm the normal vector pointing towards c, the centroid.
     # This ensures that the inequality norm * x >= 0 describes all points on the same side of p1' as c.
     # Adding a condition like this for each edge of p1 bounds our search to just points on p1.
     for i, norm in enumerate(p1_ortho_planes):
@@ -1073,7 +1074,7 @@ def closest_points_between_planes(
     ]
 
     def distance(x):
-        # x is a numpy array 6-tuple containing the position of the points p and q.
+        # x is a numpy array of length 6 containing the position of the points p in x[:3] and q in x[3:].
         # returns ||p - q||^2
         return sp.spatial.distance.cdist(
             x[:3].reshape((1, 3)), x[3:].reshape((1, 3)), metric="sqeuclidean"
@@ -1101,7 +1102,7 @@ def closest_points_between_planes(
 def closest_points_between_plane_sequences(
     sequence1_planes: np.ndarray, sequence2_planes: np.ndarray
 ) -> Tuple[np.ndarray, np.ndarray]:
-    """Find the closest points between two sequences of planes
+    """Find the closest points between two sequences of planes.
 
     Parameters
     ----------
@@ -1113,7 +1114,7 @@ def closest_points_between_plane_sequences(
     Returns
     -------
     (np.ndarray, np.ndarray)
-        Points (p, q) minimising ||p - q|| such that p lies on sequence1_planes and
+        Points (p, q) minimising ||p - q||, such that p lies on sequence1_planes and
         q lies on sequence2_planes.
 
     """


### PR DESCRIPTION
Adds two key functions `closest_points_between_planes` and `closest_points_between_plane_sequences` that compute the two closest points between two planes and two connected sequences of planes, respectively. This is necessary to enable a highly parallelised computation of type-5 SRF files. The main function, `closest_points_between_planes` uses the constrained optimisers from scipy, and relies on some geometry to compute the constraints required to keep the two points on the planes. Where such geometry may not be known to the reader, I have added some explanatory comments.

NB: because this code uses an optimiser rather than explicitly solving for the closest points, the computed points are only approximate. My tests seem to indicate that each coordinate is no more than 1e-7 away from the correct coordinates in absolute value (see the test file).