### PR TITLE
Add oriented bearing function

### DIFF
--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -155,7 +155,8 @@ def oriented_bearing_wrt_normal(
     """Compute the oriented bearing from u to v with respect to a normal.
 
     This function is useful to calculate, for example, strike and dip
-    directions. The orientation is established via the right hand rule (or refer to the diagram below).
+    directions. The orientation is established via the right hand rule
+    (or refer to the diagram below).
 
            v
            ^

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -6,7 +6,7 @@ import functools
 import itertools
 from math import acos, asin, atan, atan2, cos, degrees, pi, radians, sin, sqrt
 from subprocess import PIPE, Popen
-from typing import Tuple, Union, Dict, Any, List
+from typing import Any, Dict, List, Tuple, Union
 from warnings import warn
 
 import numpy as np
@@ -158,7 +158,7 @@ def oriented_bearing_wrt_normal(
     directions. The orientation is established via the right hand rule
     (or refer to the diagram below).
 
-        to_bearing
+        to_direction
            ^
            │
            │

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -149,6 +149,56 @@ def ll2gp_multi(
     return xy
 
 
+def oriented_bearing_wrt_normal(
+    u: np.ndarray, v: np.ndarray, normal: np.ndarray
+) -> float:
+    """Compute the oriented bearing from u to v with respect to a normal.
+
+    This function is useful to calculate, for example, strike and dip
+    directions. The orientation is established via the right hand rule (or refer to the diagram below).
+
+           v
+           ^
+           │
+           │
+           │
+           │
+           │
+           │<┐
+           │ └─┐
+           ╳─────────────>u
+          ╱
+         ╱
+        ╱
+       ╱
+    normal
+
+    Parameters
+    ----------
+    u : np.ndarray
+    v : np.ndarray
+    normal : np.ndarray
+
+    Returns
+    -------
+    float
+        The bearing from u to v with oriented with respect to normal.
+
+    Examples
+    --------
+    >>> oriented_bearing_wrt_normal(np.array([0, 1, 0]), np.array([1, 0, 0]), np.array([0, 0, 1]))
+    270
+    >>> oriented_bearing_wrt_normal(np.array([1, 0, 0]), np.array([0, 1, 0]), np.array([0, 0, 1]))
+    90
+    """
+
+    u_hat = u / np.linalg.norm(u)
+    v_hat = v / np.linalg.norm(v)
+    angle_signed = np.arccos(np.dot(u_hat, v_hat))
+    orientation = np.sign(np.dot(np.cross(u, v), normal))
+    return np.degrees(angle_signed * orientation) % 360
+
+
 def ll2gp(
     lat, lon, mlat, mlon, rot, nx, ny, hh, dx=1, dy=1, decimated=False, verbose=False
 ):

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -186,7 +186,8 @@ def oriented_bearing_wrt_normal(
     Returns
     -------
     float
-        The bearing from u to v with oriented with respect to normal.
+        The bearing from from_direction to to_direction oriented with respect to
+        the normal direction.
 
     Examples
     --------

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -150,24 +150,24 @@ def ll2gp_multi(
 
 
 def oriented_bearing_wrt_normal(
-    u: np.ndarray, v: np.ndarray, normal: np.ndarray
+    from_direction: np.ndarray, to_direction: np.ndarray, normal: np.ndarray
 ) -> float:
-    """Compute the oriented bearing from u to v with respect to a normal.
+    """Compute the oriented bearing between two directions with respect to a normal.
 
     This function is useful to calculate, for example, strike and dip
     directions. The orientation is established via the right hand rule
     (or refer to the diagram below).
 
-           v
+        to_bearing
            ^
            │
            │
            │
            │
            │
-           │<┐
+           │<┐  bearing
            │ └─┐
-           ╳─────────────>u
+           ╳─────────────> from_direction
           ╱
          ╱
         ╱
@@ -176,9 +176,12 @@ def oriented_bearing_wrt_normal(
 
     Parameters
     ----------
-    u : np.ndarray
-    v : np.ndarray
+    from_direction : np.ndarray
+        The direction to measure the bearing from.
+    to_direction : np.ndarray
+        The direction to measure the bearing to.
     normal : np.ndarray
+        The normal direction to orient the bearing with via the right hand rule.
 
     Returns
     -------
@@ -193,10 +196,10 @@ def oriented_bearing_wrt_normal(
     90
     """
 
-    u_hat = u / np.linalg.norm(u)
-    v_hat = v / np.linalg.norm(v)
-    angle_signed = np.arccos(np.dot(u_hat, v_hat))
-    orientation = np.sign(np.dot(np.cross(u, v), normal))
+    from_dir_hat = from_direction / np.linalg.norm(from_direction)
+    to_dir_hat = to_direction / np.linalg.norm(to_direction)
+    angle_signed = np.arccos(np.dot(from_dir_hat, to_dir_hat))
+    orientation = np.sign(np.dot(np.cross(from_direction, to_direction), normal))
     return np.degrees(angle_signed * orientation) % 360
 
 

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -6,7 +6,7 @@ import functools
 import itertools
 from math import acos, asin, atan, atan2, cos, degrees, pi, radians, sin, sqrt
 from subprocess import PIPE, Popen
-from typing import Any, Dict, List, Tuple, Union
+from typing import List, Tuple, Union
 from warnings import warn
 
 import numpy as np


### PR DESCRIPTION
Add a function to compute the oriented bearing between two vectors. Not sure how this wasn't already in qcore because it's super useful for finding the strike or dip direction between corners. Here is, for example, how I am using to find the strike direction of a fault given the corners of the fault:

```python
north_direction = np.array([1, 0, 0])
up_direction = np.array([0, 0, 1])
strike_direction = self._corners[1] - self._corners[0]
return qcore.geo.oriented_bearing_wrt_normal(
    north_direction, strike_direction, up_direction
)
```