### PR TITLE
Improve xyts module

### DIFF
--- a/qcore/xyts.py
+++ b/qcore/xyts.py
@@ -330,7 +330,7 @@ class XYTSFile:
         Parameters
         ----------
         corners : Optional[np.ndarray]
-            If not None, use precalculated corners
+            If not None, use the given precalculated corners.
 
         Returns
         -------

--- a/qcore/xyts.py
+++ b/qcore/xyts.py
@@ -251,9 +251,9 @@ class XYTSFile:
             mmiv = np.vstack((self.ll_map.reshape(-1, 2).T, mmiv)).T
 
         # store / output
-        if pgvout != None:
+        if pgvout is not None:
             pgv.astype(np.float32).tofile(pgvout)
-        if mmi and mmiout != None:
+        if mmi and mmiout is not None:
             mmiv.astype(np.float32).tofile(mmiout)
 
         if pgvout is None:

--- a/qcore/xyts.py
+++ b/qcore/xyts.py
@@ -1,12 +1,41 @@
 """
-Read xyts.e3d files.
-C structs available in WccFormat/src/structure.h
-XYTS file related functions.
-XYTS files contain time slices on the X-Y plane (z = 1, top level).
-XYTS file processing
+This module provides functionality to read xyts files.
 
-@author Viktor Polak
-@date 19 January 2017
+Extended Summary
+----------------
+This module includes the XYTSFile class, which represents an XYTS file. It
+allows users to load metadata, retrieve data, and calculate PGV (Peak Ground
+Velocity) and MMI (Modified Mercalli Intensity) values from the XYTS file.
+
+Classes
+----------------
+- XYTSFile: Represents an XYTS file and provides methods to interact with it.
+
+Notes
+-----
+- This module assumes that the simulation domain is flat, and the timeseries
+  contained inside the xyts files begins at t = 0.
+
+References
+----------
+- XYTS file format documentation:
+    https://wiki.canterbury.ac.nz/x/FAGnAw#FileFormatsUsedInGroundMotionSimulation-XYTS.e3dbinaryformat
+- C struct metadata definition:
+    merge_ts/structure.h (in the EMOD3D repository)
+
+Examples
+--------
+# Load an XYTS file
+xyts_file = XYTSFile("example.x3d")
+
+# Retrieve corners of the simulation domain
+corners = xyts_file.corners()
+
+# Retrieve PGV map
+pgv_map = xyts_file.pgv()
+
+# Calculate MMI values
+_, mmi_values = xyts_file.pgv(mmi=True)
 """
 
 import dataclasses

--- a/qcore/xyts.py
+++ b/qcore/xyts.py
@@ -115,10 +115,6 @@ class XYTSFile:
     y0: int
     z0: int
     t0: int
-    # proc-local files only
-    local_nx: Optional[int]
-    local_ny: Optional[int]
-    local_nz: Optional[int]
     #######################
     nx: int
     ny: int
@@ -142,17 +138,24 @@ class XYTSFile:
     cosP: float
     sinP: float
     rot_matrix: np.ndarray
+    # proc-local files only
+    local_nx: Optional[int] = None
+    local_ny: Optional[int] = None
+    local_nz: Optional[int] = None
 
     # contents
-    data: np.memmap  # NOTE: this is distinct (but nearly identical to) a np.ndarray
+    data: Optional[np.memmap] = (
+        None  # NOTE: this is distinct (but nearly identical to) a np.ndarray
+    )
 
-    ll_map: np.ndarray
+    ll_map: Optional[np.ndarray] = None
 
     def __init__(
         self,
         xyts_path: Path | str,
         meta_only: bool = False,
         proc_local_file: bool = False,
+        round_dt: bool = True,
     ):
         """Initializes the XYTSFile object.
 
@@ -165,6 +168,9 @@ class XYTSFile:
             locations (slower).
         proc_local_file : bool
             If True, indicates a proc-local file.
+        round_dt : bool
+            If True, round the dt value to 4dp (present only for backwards
+            compatibility).
 
         Raises
         ------
@@ -207,7 +213,8 @@ class XYTSFile:
         )
         xytf.close()
         # dt is sensitive to float error eg 0.2 stores as 0.199999 (dangerous)
-        self.dt = np.around(dt, decimals=4)
+        if round_dt:
+            self.dt = np.around(self.dt, decimals=4)
 
         # determine original sim parameters
         self.dxts = int(round(self.dx / self.hh))

--- a/qcore/xyts.py
+++ b/qcore/xyts.py
@@ -41,7 +41,7 @@ _, mmi_values = xyts_file.pgv(mmi=True)
 import dataclasses
 from math import cos, radians, sin
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -132,7 +132,7 @@ class XYTSFile:
     dyts: int
     nx_sim: int
     dip: float
-    comps: dict[str, float]
+    comps: Dict[str, float]
     cosR: float
     sinR: float
     cosP: float
@@ -152,7 +152,7 @@ class XYTSFile:
 
     def __init__(
         self,
-        xyts_path: Path | str,
+        xyts_path: Union[Path, str],
         meta_only: bool = False,
         proc_local_file: bool = False,
         round_dt: bool = True,
@@ -281,7 +281,7 @@ class XYTSFile:
 
     def corners(
         self, gmt_format: bool = False
-    ) -> list[list[float]] | Tuple[list[list[float]], str]:
+    ) -> Union[List[List[float]], Tuple[List[List[float]], str]]:
         """Retrieves the corners of the simulation domain.
 
         Parameters
@@ -292,7 +292,7 @@ class XYTSFile:
 
         Returns
         -------
-        list[list[float]] | Tuple[list[list[float]], str]
+        List[List[float]] | Tuple[List[List[float]], str]
             List of corners and (optionally) GMT string.
         """
         # compared with model_params format:
@@ -345,7 +345,7 @@ class XYTSFile:
         return (x_min, x_max, y_min, y_max)
 
     def tslice_get(
-        self, step: int, comp: int = -1, outfile: Optional[Path | str] = None
+        self, step: int, comp: int = -1, outfile: Optional[Union[Path, str]] = None
     ) -> np.ndarray:
         """Retrieves timeslice data.
 
@@ -387,9 +387,9 @@ class XYTSFile:
     def pgv(
         self,
         mmi: bool = False,
-        pgvout: Optional[Path | str] = None,
-        mmiout: Optional[Path | str] = None,
-    ) -> None | np.ndarray | Tuple[np.ndarray, np.ndarray]:
+        pgvout: Optional[Union[Path, str]] = None,
+        mmiout: Optional[Union[Path, str]] = None,
+    ) -> Union[None, np.ndarray, Tuple[np.ndarray, np.ndarray]]:
         """Retrieves PGV and/or MMI map.
 
         Parameters


### PR DESCRIPTION
The following pull request makes a couple of changes to the `xyts` module, which is being updated to facilitate the merge_ts python rewrite. 

1. It is now properly documented and typed.
2. Support for processor local files (output of EMOD3D pre-merging)
3. The rounding behaviour of dt is now optional, but defaults to the prior behaviour (useful for merge_ts).

this change should not affect any code downstream. This module is used in exactly one place (in plot_ts), so I will check this when I test merge_ts_py properly.