### PR TITLE
Fix GMT land optimisation

### DIFF
--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -678,7 +678,7 @@ def path_from_corners(
     if output is not None:
         with open(output, "w", encoding="utf-8") as mp:
             for point in corners:
-                mp.write(f"{point[0]} {point[1]}")
+                mp.write(f"{point[0]} {point[1]}\n")
     else:
         return corners
 


### PR DESCRIPTION
Fixes the `path_from_corners` function to add a newline after write (a small typo from the geo.py cleanup). This was causing GMT to blow up when running.