### PR TITLE
Update install requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 import os
-from setuptools import setup
 import sys
 import tarfile
 from urllib.request import urlretrieve
 
+from setuptools import setup
 
 PACKAGE_NAME = "qcore"
 PACKAGE_URL = f"https://github.com/ucgmsim/{PACKAGE_NAME}"
@@ -65,5 +65,14 @@ setup(
         "qcore": [os.path.join("configs", "*.json"), "data/*", "data/*/*", "data/*/*/*"]
     },
     include_package_data=True,
-    install_requires=["numpy", "scipy>=0.16", "dataclasses"],
+    install_requires=[
+        "numpy",
+        "scipy>=0.16",
+        "dataclasses",
+        "alphashape",
+        "descartes",
+        "pyproj",
+        "shapely",
+        "numba",
+    ],
 )


### PR DESCRIPTION
This hasn't been updated in a while. It makes it hard to install qcore (e.g. if you're making a new environment in workflow you have to `pip install -r requirements.txt`). This just updates the qcore dependencies so they install when qcore does. 