### PR TITLE
Fix the Oriented Bearing Function

### DIFF
--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -149,7 +149,7 @@ def ll2gp_multi(
 
 def oriented_bearing_wrt_normal(
     from_direction: np.ndarray, to_direction: np.ndarray, normal: np.ndarray
-) -> float:
+) -> np.float64:
     """Compute the oriented bearing between two directions with respect to a normal.
 
     This function is useful to calculate, for example, strike and dip

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -199,7 +199,7 @@ def oriented_bearing_wrt_normal(
     to_dir_hat = to_direction / np.linalg.norm(to_direction)
     angle_signed = np.arccos(np.dot(from_dir_hat, to_dir_hat))
     orientation = np.sign(np.dot(np.cross(from_direction, to_direction), normal))
-    return np.degrees(angle_signed * orientation) % 360
+    return np.degrees(angle_signed * (orientation or 1)) % 360
 
 
 def ll2gp(
@@ -878,7 +878,6 @@ def orthogonal_plane(pi: np.ndarray, p: np.ndarray, q: np.ndarray) -> np.ndarray
 def oriented_bounding_planes(
     plane_dual_coordinates: np.ndarray, plane_corners: np.ndarray
 ) -> List[np.ndarray]:
-
     plane_centroid = np.average(plane_corners, axis=0)
     # For each side of the plane p1, we construct a plane orthogonal to p1
     # passing through the side.

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -199,6 +199,9 @@ def oriented_bearing_wrt_normal(
     to_dir_hat = to_direction / np.linalg.norm(to_direction)
     angle_signed = np.arccos(np.dot(from_dir_hat, to_dir_hat))
     orientation = np.sign(np.dot(np.cross(from_direction, to_direction), normal))
+    # If the from_direction ~ +/- to_direction, orientation (and so
+    # bearing) will be zero. The expression (orientation or 1) ensures
+    # that bearings of 180 degrees are handled correctly.
     return np.degrees(angle_signed * (orientation or 1)) % 360
 
 

--- a/qcore/test/test_geo/test_geo.py
+++ b/qcore/test/test_geo/test_geo.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 import scipy as sp
+from hypothesis import given
+from hypothesis import strategies as st
 
 from qcore import geo
 from qcore.test.tool import utils
@@ -92,6 +94,22 @@ def test_ll_shift(
 )
 def test_avg_wbearing(test_angles, output_degrees):
     assert geo.avg_wbearing(test_angles) == output_degrees
+
+
+@given(target_bearing=st.floats(0, 360))
+def test_oriented_bearing_wrt_normal(target_bearing: float):
+    to_direction = np.array(
+        [np.cos(np.radians(target_bearing)), np.sin(np.radians(target_bearing)), 0]
+    )
+    from_direction = np.array([1, 0, 0])
+    up_direction = np.array([0, 0, 1])
+    calculated_bearing = geo.oriented_bearing_wrt_normal(
+        from_direction, to_direction, up_direction
+    )
+    assert (calculated_bearing == pytest.approx(target_bearing, abs=0.1)) or (
+        target_bearing == pytest.approx(360, abs=0.1)
+        and calculated_bearing == pytest.approx(0, abs=0.1)
+    )
 
 
 @pytest.mark.parametrize(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ descartes
 pyproj
 shapely
 numba
+hypothesis[numpy]


### PR DESCRIPTION
Small fix so that oriented bearings of 180 degrees are not confused with oriented bearings of 0 degrees. Found whilst hypothesis testing the bounding box module.