### PR TITLE
Use numpy<2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import os
-from setuptools import setup
 
+from setuptools import setup
 
 setup(
     name="qcore",
@@ -13,7 +13,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        "numpy",
+        "numpy<2",
         "scipy>=0.16",
         "dataclasses",
         "alphashape",


### PR DESCRIPTION
We should probably also check that all our other repos do this because if there is even one that doesn't it causes annoying problems with conflicting versions of numpy.