### PR TITLE
Optional[A | B] is not supported in old Python

### DIFF
--- a/qcore/config.py
+++ b/qcore/config.py
@@ -73,7 +73,7 @@ def determine_machine_config(hostname: str = node()) -> Tuple[str, str]:
     config_path = Path(__file__).resolve().parent / "configs" / basename
     return machine, str(config_path)
 
-
+# TODO:  For Python > 3.9, use Optional[Path | str]
 def get_machine_config(
     hostname: str = node(), config_path: Optional[Union[Path, str]] = None
 ) -> ConfigDict:

--- a/qcore/config.py
+++ b/qcore/config.py
@@ -73,7 +73,7 @@ def determine_machine_config(hostname: str = node()) -> Tuple[str, str]:
     config_path = Path(__file__).resolve().parent / "configs" / basename
     return machine, str(config_path)
 
-# TODO:  For Python > 3.9, use Optional[Path | str]
+# TODO:  Use  Optional[Path | str] if Maui and Nurion support newer Python (3.10+)
 def get_machine_config(
     hostname: str = node(), config_path: Optional[Union[Path, str]] = None
 ) -> ConfigDict:

--- a/qcore/config.py
+++ b/qcore/config.py
@@ -27,7 +27,7 @@ from enum import Enum, auto
 from json import load
 from pathlib import Path
 from platform import node
-from typing import Optional, Tuple, TypedDict
+from typing import Optional, Tuple, TypedDict, Union
 
 
 class ConfigDict(TypedDict):
@@ -75,7 +75,7 @@ def determine_machine_config(hostname: str = node()) -> Tuple[str, str]:
 
 
 def get_machine_config(
-    hostname: str = node(), config_path: Optional[Path | str] = None
+    hostname: str = node(), config_path: Optional[Union[Path, str]] = None
 ) -> ConfigDict:
     """Get the current machine config.
 


### PR DESCRIPTION
We have Python 3.9 on Maui and 3.7 on Nurion.

Optional[A | B]  should be Optional[Union[A,B]] while we need to support these machines..