### PR TITLE
Add Bearing Correction Functions for NZTM and Great-circle Geometry

### DIFF
--- a/qcore/coordinates.py
+++ b/qcore/coordinates.py
@@ -22,6 +22,8 @@ from typing import Union
 import numpy as np
 import pyproj
 
+from qcore import geo
+
 # Module level conversion constants for internal use only.
 _WGS_CODE = 4326
 _NZTM_CODE = 2193
@@ -138,3 +140,75 @@ def distance_between_wgs_depth_coordinates(
             wgs_depth_to_nztm(point_a) - wgs_depth_to_nztm(point_b), axis=1
         )
     return np.linalg.norm(wgs_depth_to_nztm(point_a) - wgs_depth_to_nztm(point_b))
+
+
+def nztm_bearing_correction(
+    origin: np.ndarray, distance: float, nztm_bearing: float
+) -> float:
+    """Correct a NZTM bearing to match a great circle bearing.
+
+    This function can be used to translate bearings computed from NZTM
+    coordinates into equivalent bearings in great-circle geometry.
+    Primarily useful in ensuring tools like NZVM and EMOD3D agree on
+    domain corners with newer code using NZTM. This correction is
+    larger as the origin moves farther south, as the nztm bearing varies,
+    and (slightly) as distance increases.
+
+    Parameters
+    ----------
+    origin : np.ndarray
+        The origin point to compute the bearing from.
+    distance : float
+        The distance to shift.
+    nztm_bearing : float
+        The NZTM bearing for the final point.
+
+    Returns
+    -------
+    float
+        The equivalent bearing such that:
+        `geo.ll_shift`(*`origin`, `distance`, bearing) ≅ `nztm_heading`.
+    """
+    nztm_heading = nztm_to_wgs_depth(
+        wgs_depth_to_nztm(origin)
+        + distance
+        * 1000
+        * np.array([np.cos(np.radians(nztm_bearing)), np.sin(np.radians(nztm_bearing))])
+    )
+    return geo.ll_bearing(*origin[::-1], *nztm_heading[::-1])
+
+
+def ll_bearing_correction(
+    origin: np.ndarray, distance: float, ll_bearing: float
+) -> float:
+    """Correct a great circle bearing to match a NZTM bearing.
+
+    This function can be used to translate bearings computed from
+    great-circle geometry to equivalent bearings in NZTM coordinates.
+    Primarily useful in ensuring tools like NZVM and EMOD3D agree on
+    domain corners with newer code using NZTM. This correction is
+    larger as the origin moves farther south, as the nztm bearing
+    varies, and (slightly) as distance increases.
+
+    Parameters
+    ----------
+    origin : np.ndarray
+        The origin point to compute the bearing from.
+    distance : float
+        The distance to shift.
+    ll_bearing : float
+        The great circle bearing for the final point.
+
+    Returns
+    -------
+    float
+        The equivalent bearing such that:
+        `geo.ll_shift`(*`origin`, `distance`, `ll_bearing`) ≅ nztm_heading.
+    """
+    ll_heading = np.array(geo.ll_shift(*origin, distance, ll_bearing))
+
+    return geo.oriented_bearing_wrt_normal(
+        np.array([1, 0, 0]),
+        np.append(wgs_depth_to_nztm(ll_heading) - wgs_depth_to_nztm(origin), 0),
+        np.array([0, 0, 1]),
+    )

--- a/qcore/coordinates.py
+++ b/qcore/coordinates.py
@@ -142,7 +142,7 @@ def distance_between_wgs_depth_coordinates(
     return np.linalg.norm(wgs_depth_to_nztm(point_a) - wgs_depth_to_nztm(point_b))
 
 
-def nztm_bearing_correction(
+def nztm_bearing_to_great_circle_bearing(
     origin: np.ndarray, distance: float, nztm_bearing: float
 ) -> float:
     """Correct a NZTM bearing to match a great circle bearing.
@@ -178,8 +178,8 @@ def nztm_bearing_correction(
     return geo.ll_bearing(*origin[::-1], *nztm_heading[::-1])
 
 
-def ll_bearing_correction(
-    origin: np.ndarray, distance: float, ll_bearing: float
+def great_circle_bearing_to_nztm_bearing(
+    origin: np.ndarray, distance: float, great_circle_bearing: float
 ) -> float:
     """Correct a great circle bearing to match a NZTM bearing.
 
@@ -205,10 +205,14 @@ def ll_bearing_correction(
         The equivalent bearing such that:
         `geo.ll_shift`(*`origin`, `distance`, `ll_bearing`) ≅ nztm_heading.
     """
-    ll_heading = np.array(geo.ll_shift(*origin, distance, ll_bearing))
+    great_circle_heading = np.array(
+        geo.ll_shift(*origin, distance, great_circle_bearing)
+    )
 
     return geo.oriented_bearing_wrt_normal(
         np.array([1, 0, 0]),
-        np.append(wgs_depth_to_nztm(ll_heading) - wgs_depth_to_nztm(origin), 0),
+        np.append(
+            wgs_depth_to_nztm(great_circle_heading) - wgs_depth_to_nztm(origin), 0
+        ),
         np.array([0, 0, 1]),
     )


### PR DESCRIPTION
I have added two functions to the coordinates module, which translates bearings between great-circle geometry bearings and nztm bearing (and vice-versa).

# Why do we need this?

We have two ways of computing bearings between points:

1. Using `geo.ll_bearing`, which utilises great-circle geometry (assuming the earth is a sphere) and,
2. Using the `coordinates` module to transform lat-lon into NZTM coordinates, and computing the bearing using standard euclidean geometry.

The issue is that these two methods do not agree entirely because NZTM gives a different (more accurate, for New Zealand) model for the surface of the Earth than great-circle geometry because the earth is ellipsoidal. This means starting at (-43.538, 172.6474) and travelling at a 45 degree bearing for 100km using `geo.ll_shift` is different to converting that same coordinate to NZTM and then adding $1e5 * (1/\sqrt{2}, 1/\sqrt{2})$ to travel at a 45 degree bearing for 100 km. The difference in final destination for that example will be about a kilometre.

What we need here is a correction, a function that can compute the angle that gets the NZTM bearing as close to the great-circle bearing as possible. This correction computation is the point of the PR.

The correction required depends on the distance travelled, the initial bearing, and most importantly on the origin point. The difference in bearing is largest in my testing when the origin is in Fiordland and near Auckland. Here the bearing correction can be up to 3 or 4 degrees. **See the comments for an example of how big the effect can be**.

# What Have We Added?

We have added two functions that translate bearings between great-circle geometry:

1. `nztm_bearing_to_great_circle_bearing` which computes the great-circle equivalent bearing for an NZTM bearing,
2. `great_circle_bearing_to_nztm_bearing` which computes the NZTM equivalent bearing for a great-circle bearing.