### PR TITLE
Fix : np.unicode_ was removed in the Numpy2.0 release.

### DIFF
--- a/qcore/timeseries.py
+++ b/qcore/timeseries.py
@@ -758,7 +758,7 @@ class BBSeis:
         # read header - strings
         self.lf_dir, self.lf_vm, self.hf_file = np.fromfile(
             bbf, count=3, dtype="|S256"
-        ).astype(np.unicode_)
+        ).astype(np.str_)
 
         # load station info
         bbf.seek(self.HEAD_SIZE)


### PR DESCRIPTION
Numpy >=2.0 has this issue and BB step in the workflow will fail the test because BB.bin can't be loaded.


```
>>> from qcore import timeseries
>>> bb=timeseries.BBSeis("BB.bin")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/scale_wlg_persistent/filesets/project/nesi00213/Environments/baes2024/qcore/qcore/timeseries.py", line 761, in __init__
    ).astype(np.unicode_)
  File "/scale_wlg_persistent/filesets/project/nesi00213/Environments/baes2024/virt_envs/python3_maui/lib/python3.9/site-packages/numpy/__init__.py", line 397, in __getattr__
    raise AttributeError(
AttributeError: `np.unicode_` was removed in the NumPy 2.0 release. Use `np.str_` instead.
```
