### PR TITLE
Validate vm bounds

### DIFF
--- a/qcore/validate_vm.py
+++ b/qcore/validate_vm.py
@@ -107,7 +107,7 @@ def validate_vm_params(vm_params: str, srf: str = None):
     if srf is not None:
         srf_bounds = get_bounds(srf)
     else:
-        srf_bounds = None
+        srf_bounds = []
     errors.extend(validate_vm_bounds(polygon, srf_bounds))
 
     if errors:
@@ -177,7 +177,7 @@ def validate_vm_files(vm_dir: str, srf: str = None):
         if srf is not None:
             srf_bounds = get_bounds(srf)
         else:
-            srf_bounds = None
+            srf_bounds = []
         errors.extend(validate_vm_bounds(polygon, srf_bounds))
 
     if errors:

--- a/qcore/validate_vm.py
+++ b/qcore/validate_vm.py
@@ -225,23 +225,22 @@ def validate_vm_bounds(polygon: npt.ArrayLike, srf_bounds: npt.ArrayLike):
     """
 
     errors = []
+    assert len(srf_bounds) > 0, "No srf bounds given"
 
-    if len(srf_bounds) > 0:
-        vm_polygon = Polygon(
-            coordinates.wgs_depth_to_nztm(
-                np.array(polygon)[:, [1, 0]]
-            )  # [lon, lat] to [lat, lon]
-        )
+    # Check if the SRF domain is within the VM domain
+    vm_polygon = Polygon(
+        coordinates.wgs_depth_to_nztm(
+            np.array(polygon)[:, [1, 0]]
+        )  # [lon, lat] to [lat, lon]
+    )
 
-        all_inside = all(
-            vm_polygon.contains(
-                Point(coordinates.wgs_depth_to_nztm(np.array([lat, lon])))
-            )
-            for plane in srf_bounds
-            for lon, lat in plane
-        )
-        if not all_inside:
-            errors.append("Srf extents not contained within velocity model corners")
+    all_inside = all(
+        vm_polygon.contains(Point(coordinates.wgs_depth_to_nztm(np.array([lat, lon]))))
+        for plane in srf_bounds
+        for lon, lat in plane
+    )
+    if not all_inside:
+        errors.append("Srf extents not contained within velocity model corners")
 
     return errors
 

--- a/qcore/validate_vm.py
+++ b/qcore/validate_vm.py
@@ -209,19 +209,22 @@ def validate_vm_bounds(
         if lon < MIN_LON or lon > MAX_LON or lat < MIN_LAT or lat > MAX_LAT:
             errors.append(f"VM extents not contained within NZVM DEM: {lon}, {lat}")
 
-    vm_polygon = Polygon(
-        coordinates.wgs_depth_to_nztm(
-            np.array(polygon)[:, [1, 0]]
-        )  # [lon, lat] to [lat, lon]
-    )
+    if len(srf_bounds) > 0:
+        vm_polygon = Polygon(
+            coordinates.wgs_depth_to_nztm(
+                np.array(polygon)[:, [1, 0]]
+            )  # [lon, lat] to [lat, lon]
+        )
 
-    all_inside = all(
-        vm_polygon.contains(Point(coordinates.wgs_depth_to_nztm(np.array([lat, lon]))))
-        for plane in srf_bounds
-        for lon, lat in plane
-    )
-    if not all_inside:
-        errors.append("Srf extents not contained within velocity model corners")
+        all_inside = all(
+            vm_polygon.contains(
+                Point(coordinates.wgs_depth_to_nztm(np.array([lat, lon])))
+            )
+            for plane in srf_bounds
+            for lon, lat in plane
+        )
+        if not all_inside:
+            errors.append("Srf extents not contained within velocity model corners")
 
     return errors
 

--- a/qcore/validate_vm.py
+++ b/qcore/validate_vm.py
@@ -16,10 +16,14 @@ fi
 
 import argparse
 from pathlib import Path
+from typing import Optional
 
 import matplotlib.path as mpltPath
 import numpy as np
+import numpy.typing as npt
+from shapely.geometry import Point, Polygon
 
+from qcore import coordinates
 from qcore.utils import load_yaml
 from qcore.constants import VM_PARAMS_FILE_NAME, VMParams
 from qcore.srf import get_bounds
@@ -181,37 +185,42 @@ def validate_vm_files(vm_dir: str, srf: str = None):
     return True, ""
 
 
-def validate_vm_bounds(polygon, srf_bounds=None):
+def validate_vm_bounds(polygon: np.array, srf_bounds: Optional[npt.ArrayLike] = []):
     """
     Validates the VM domain against the DEM and the srf bounds
-    :param polygon: A list of (lon, lat) tuples giving the corners of the VM
-    :param srf: A list of (lon, lat) tuples giving the corners of the VM. Not used if None
-    :return: A list of error messages resulting from this validation
+
+    Parameters
+    ----------
+    polygon : np.array
+        Corners of the VM domain. Formatted as [[lon, lat], [lon, lat], [lon, lat], [lon, lat]]
+    srf_bounds : np.ndarray , list etc, optional
+        Corners of SRF planes. Can be multiple planes,  Formatted as [plane1, plane2,...] where plane1=[[lon,lat],[lon,lat],[lon,lat],[lon,lat]]
+
+    Returns
+    -------
+    A list of error messages resulting from this validation
     """
+
     errors = []
 
     for lon, lat in polygon:
         if lon < MIN_LON or lon > MAX_LON or lat < MIN_LAT or lat > MAX_LAT:
             errors.append(f"VM extents not contained within NZVM DEM: {lon}, {lat}")
-    # Check SRF is within bounds of the VM if it is given
-    if srf_bounds is not None:
-        edges = []
-        for index, start_point in enumerate(polygon):
-            end_point = polygon[(index + 1) % len(polygon)]
-            lons = (
-                np.linspace(
-                    start_point[0],
-                    end_point[0],
-                    int(max(ll_dist(*start_point, *end_point), 3)),
-                )
-                % 360
-            )
-            lats = compute_intermediate_latitudes(start_point, end_point, lons)
-            edges.extend(list(zip(lons, lats)))
-        path = mpltPath.Path(edges)
-        for bounds in srf_bounds:
-            if not all(path.contains_points(bounds)):
-                errors.append("Srf extents not contained within velocity model corners")
+
+    vm_polygon = Polygon(
+        coordinates.wgs_depth_to_nztm(
+            np.array(polygon)[:, [1, 0]]
+        )  # [lon, lat] to [lat, lon]
+    )
+
+    all_inside = all(
+        vm_polygon.contains(Point(coordinates.wgs_depth_to_nztm(np.array([lat, lon]))))
+        for plane in srf_bounds
+        for lon, lat in plane
+    )
+    if not all_inside:
+        errors.append("Srf extents not contained within velocity model corners")
+
     return errors
 
 

--- a/qcore/validate_vm.py
+++ b/qcore/validate_vm.py
@@ -185,15 +185,17 @@ def validate_vm_files(vm_dir: str, srf: str = None):
     return True, ""
 
 
-def validate_vm_bounds(polygon: np.array, srf_bounds: Optional[npt.ArrayLike] = []):
+def validate_vm_bounds(
+    polygon: npt.ArrayLike, srf_bounds: Optional[npt.ArrayLike] = []
+):
     """
     Validates the VM domain against the DEM and the srf bounds
 
     Parameters
     ----------
-    polygon : np.array
+    polygon : np.ndarray or list/tuple
         Corners of the VM domain. Formatted as [[lon, lat], [lon, lat], [lon, lat], [lon, lat]]
-    srf_bounds : np.ndarray , list etc, optional
+    srf_bounds : np.ndarray or list/tuple, optional
         Corners of SRF planes. Can be multiple planes,  Formatted as [plane1, plane2,...] where plane1=[[lon,lat],[lon,lat],[lon,lat],[lon,lat]]
 
     Returns


### PR DESCRIPTION
`validate_vm_bounds()` is called during the vm_params step, specifically by `rel2vm_params.py`. 

This function was originally using longitude and latitude to check inside/outside check, but it is safer to convert to the NZTM coordinates first. 

https://github.com/ucgmsim/Pre-processing/pull/238

I also found the code was not particularly efficient, as it suffices to test the srf corner points. Hence this PR.