### PR TITLE
seis2txt() was renamed to timeseries_to_text() but still referenced

### DIFF
--- a/qcore/timeseries.py
+++ b/qcore/timeseries.py
@@ -515,7 +515,7 @@ class LFSeis:
                 title=title,
             )
 
-    def all2txt(self, prefix="./", dt=None, f="vel"):
+    def all2txt(self, prefix: str = "./", dt: float = None, f: str = "vel"):
         """
         Creates waveforms in text files for all stations.
         Note: This function is not designed to be used other than for single/debug use.
@@ -715,7 +715,7 @@ class HFSeis:
                 title=title,
             )
 
-    def all2txt(self, prefix="./", dt=None):
+    def all2txt(self, prefix: str = "./", dt: float = None):
         """
         Creates waveforms in text files for all stations.
 
@@ -881,7 +881,7 @@ class BBSeis:
         if prefix is None:
             return xyz
 
-    def all2txt(self, prefix="./", f="acc"):
+    def all2txt(self, prefix: str = "./", f: str = "acc"):
         """
         Extracts waveform data from the binary file and produces output in text format.
         Note: For compatibility. Should run slices in parallel for performance.

--- a/qcore/timeseries.py
+++ b/qcore/timeseries.py
@@ -528,13 +528,12 @@ class LFSeis:
         ----------
         prefix : str, optional, default="./"
             The prefix is an output path combined with an optional filename prefix.
-            If prefix ends with /, its prefix_filename is empty, otherwise, prefix_filename is the last part of the prefix
             eg. prefix = "dir1/dir2/XXX", prefix_filename = "XXX" and prefix_dirname = "dir1/dir2"
             eg. prefix = "dir1/dir2/", prefix_filename = "" and prefix_dirname = "dir1/dir2"
-        dt : float, optional
-            The time step of the data, by default None
-        f : str, optional
-            The type of data to save, by default "acc". Options are "acc" and "vel"
+        dt : float, optional, default=None
+            The time step of the data
+        f : str, optional, default="vel"
+            The type of data to save. Options are "acc" and "vel"
         """
 
         if dt is None:
@@ -720,17 +719,13 @@ class HFSeis:
         """
         Creates waveforms in text files for all stations.
 
-        Note: This function is not designed to be used other than for single/debug use.
-        Make a parallel wrapper for any "real" use cases.
-        Produces text files previously done by script called `winbin-aio`.
-        For compatibility. Consecutive file indexes in parallel for performance.
+        Note: For compatibility. Consecutive file indexes in parallel for performance.
         Slowest part is numpy formating numbers into text and number of lines.
 
         Parameters
         ----------
         prefix : str, optional, default="./"
             The prefix is an output path combined with an optional filename prefix.
-            If prefix ends with /, its prefix_filename is empty, otherwise, prefix_filename is the last part of the prefix
             eg. prefix = "dir1/dir2/XXX", prefix_filename = "XXX" and prefix_dirname = "dir1/dir2"
             eg. prefix = "dir1/dir2/", prefix_filename = "" and prefix_dirname = "dir1/dir2"
         dt : float, optional
@@ -889,12 +884,13 @@ class BBSeis:
     def all2txt(self, prefix="./", f="acc"):
         """
         Extracts waveform data from the binary file and produces output in text format.
+        Note: For compatibility. Should run slices in parallel for performance.
+        Slowest part is numpy formating numbers into text and number of lines.
 
         Parameters
         ----------
         prefix : str, optional, default="./"
             The prefix is an output path combined with an optional filename prefix.
-            If prefix ends with /, its prefix_filename is empty, otherwise, prefix_filename is the last part of the prefix
             eg. prefix = "dir1/dir2/XXX", prefix_filename = "XXX" and prefix_dirname = "dir1/dir2"
             eg. prefix = "dir1/dir2/", prefix_filename = "" and prefix_dirname = "dir1/dir2"
         f : str, optional

--- a/qcore/timeseries.py
+++ b/qcore/timeseries.py
@@ -244,6 +244,7 @@ def timeseries_to_text(
     edist: float = 0.0,
     az: float = 0.0,
     baz: float = 0.0,
+    title: str = "",
 ):
     """
     Store timeseries data into a text file.
@@ -274,11 +275,13 @@ def timeseries_to_text(
         The azimuth forward A->B in degrees, by default 0.0
     baz : float, optional
         The azimuth backwards B->A in degrees, by default 0.0
+    title : str, optional
+        The optional title added to header
     """
     nt = timeseries.shape[0]
     with open(filename, "wb") as txt:
         # same format strings as fdbin2wcc
-        txt.write(("%-10s %3s\n" % (stat, comp)).encode())
+        txt.write(("%-10s %3s %s\n" % (stat, comp, title)).encode())
         txt.write(
             (
                 "%d %12.5e %d %d %12.5e %12.5e %12.5e %12.5e\n"
@@ -523,8 +526,19 @@ class LFSeis:
         if dt is None:
             dt = self.dt
         acc = f == "acc"
+
+        # prefix is assumed to have directory bit that ends with / and filename prefix
+        # if prefix ends with /, its prefix_filename is empty
+        # otherwise, prefix_filename is the last part of the prefix
+        # eg. prefix = "dir1/dir2/XXX", prefix_filename = "XXX" and prefix_dirname = "dir1/dir2"
+        # eg. prefix = "dir1/dir2/", prefix_filename = "" and prefix_dirname = "dir1/dir2"
+
+        prefix_chunks=prefix.split("/")
+        prefix_filename = prefix_chunks[-1]
+        prefix_dirname = Path("/".join(prefix_chunks[:-1])).resolve()
+        prefix_dirname.mkdir(parents=True,exist_ok=True)
         for s in self.stations.name:
-            self.vel2txt(s, prefix=prefix, title=prefix, dt=dt, acc=acc)
+            self.vel2txt(s, prefix=prefix, title=prefix_filename, dt=dt, acc=acc)
 
 
 ###
@@ -702,8 +716,18 @@ class HFSeis:
         """
         if dt is None:
             dt = self.dt
+        # prefix is assumed to have directory bit that ends with / and filename prefix
+        # if prefix ends with /, its prefix_filename is empty
+        # otherwise, prefix_filename is the last part of the prefix
+        # eg. prefix = "dir1/dir2/XXX", prefix_filename = "XXX" and prefix_dirname = "dir1/dir2"
+        # eg. prefix = "dir1/dir2/", prefix_filename = "" and prefix_dirname = "dir1/dir2"
+
+        prefix_chunks=prefix.split("/")
+        prefix_filename = prefix_chunks[-1]
+        prefix_dirname = Path("/".join(prefix_chunks[:-1])).resolve()
+        prefix_dirname.mkdir(parents=True,exist_ok=True)
         for s in self.stations.name:
-            self.acc2txt(s, prefix=prefix, title=prefix, dt=dt)
+            self.acc2txt(s, prefix=prefix, title=prefix_filename, dt=dt)
 
 
 ###
@@ -833,7 +857,7 @@ class BBSeis:
                 timeseries_to_text(
                     c,
                     f"{prefix}{station}.{self.COMP_NAME[i]}",
-                    dt,
+                    self.dt,
                     station,
                     self.COMP_NAME[i],
                     start_sec=self.start_sec,
@@ -850,8 +874,20 @@ class BBSeis:
         For compatibility. Should run slices in parallel for performance.
         Slowest part is numpy formating numbers into text and number of lines.
         """
+        # prefix is assumed to have directory bit that ends with / and filename prefix
+        # if prefix ends with /, its prefix_filename is empty
+        # otherwise, prefix_filename is the last part of the prefix
+        # eg. prefix = "dir1/dir2/XXX", prefix_filename = "XXX" and prefix_dirname = "dir1/dir2"
+        # eg. prefix = "dir1/dir2/", prefix_filename = "" and prefix_dirname = "dir1/dir2"
+
+        prefix_chunks=prefix.split("/")
+        prefix_filename = prefix_chunks[-1]
+        prefix_dirname = Path("/".join(prefix_chunks[:-1])).resolve()
+        prefix_dirname.mkdir(parents=True,exist_ok=True)
         for s in self.stations.name:
-            self.save_txt(s, prefix=prefix, title=prefix, f=f)
+            self.save_txt(s, prefix=prefix, title=prefix_filename, f=f)
+
+
 
     def save_ll(self, path):
         """

--- a/qcore/timeseries.py
+++ b/qcore/timeseries.py
@@ -517,26 +517,34 @@ class LFSeis:
 
     def all2txt(self, prefix="./", dt=None, f="vel"):
         """
-        NOTE: This function is not designed to be used other than for single/debug use.
+        Creates waveforms in text files for all stations.
+        Note: This function is not designed to be used other than for single/debug use.
         Make a parallel wrapper for any "real" use cases.
         Produces text files previously done by script called `winbin-aio`.
         For compatibility. Consecutive file indexes in parallel for performance.
         Slowest part is numpy formating numbers into text and number of lines.
+
+        Parameters
+        ----------
+        prefix : str, optional, default="./"
+            The prefix is an output path combined with an optional filename prefix.
+            If prefix ends with /, its prefix_filename is empty, otherwise, prefix_filename is the last part of the prefix
+            eg. prefix = "dir1/dir2/XXX", prefix_filename = "XXX" and prefix_dirname = "dir1/dir2"
+            eg. prefix = "dir1/dir2/", prefix_filename = "" and prefix_dirname = "dir1/dir2"
+        dt : float, optional
+            The time step of the data, by default None
+        f : str, optional
+            The type of data to save, by default "acc". Options are "acc" and "vel"
         """
+
         if dt is None:
             dt = self.dt
         acc = f == "acc"
 
-        # prefix is assumed to have directory bit that ends with / and filename prefix
-        # if prefix ends with /, its prefix_filename is empty
-        # otherwise, prefix_filename is the last part of the prefix
-        # eg. prefix = "dir1/dir2/XXX", prefix_filename = "XXX" and prefix_dirname = "dir1/dir2"
-        # eg. prefix = "dir1/dir2/", prefix_filename = "" and prefix_dirname = "dir1/dir2"
-
-        prefix_chunks=prefix.split("/")
+        prefix_chunks = prefix.split("/")
         prefix_filename = prefix_chunks[-1]
         prefix_dirname = Path("/".join(prefix_chunks[:-1])).resolve()
-        prefix_dirname.mkdir(parents=True,exist_ok=True)
+        prefix_dirname.mkdir(parents=True, exist_ok=True)
         for s in self.stations.name:
             self.vel2txt(s, prefix=prefix, title=prefix_filename, dt=dt, acc=acc)
 
@@ -710,22 +718,32 @@ class HFSeis:
 
     def all2txt(self, prefix="./", dt=None):
         """
-        Produces outputs as if the HF binary produced individual text files.
-        For compatibility. Should run slices in parallel for performance.
+        Creates waveforms in text files for all stations.
+
+        Note: This function is not designed to be used other than for single/debug use.
+        Make a parallel wrapper for any "real" use cases.
+        Produces text files previously done by script called `winbin-aio`.
+        For compatibility. Consecutive file indexes in parallel for performance.
         Slowest part is numpy formating numbers into text and number of lines.
+
+        Parameters
+        ----------
+        prefix : str, optional, default="./"
+            The prefix is an output path combined with an optional filename prefix.
+            If prefix ends with /, its prefix_filename is empty, otherwise, prefix_filename is the last part of the prefix
+            eg. prefix = "dir1/dir2/XXX", prefix_filename = "XXX" and prefix_dirname = "dir1/dir2"
+            eg. prefix = "dir1/dir2/", prefix_filename = "" and prefix_dirname = "dir1/dir2"
+        dt : float, optional
+            The time step of the data, by default None
         """
+
         if dt is None:
             dt = self.dt
-        # prefix is assumed to have directory bit that ends with / and filename prefix
-        # if prefix ends with /, its prefix_filename is empty
-        # otherwise, prefix_filename is the last part of the prefix
-        # eg. prefix = "dir1/dir2/XXX", prefix_filename = "XXX" and prefix_dirname = "dir1/dir2"
-        # eg. prefix = "dir1/dir2/", prefix_filename = "" and prefix_dirname = "dir1/dir2"
 
-        prefix_chunks=prefix.split("/")
+        prefix_chunks = prefix.split("/")
         prefix_filename = prefix_chunks[-1]
         prefix_dirname = Path("/".join(prefix_chunks[:-1])).resolve()
-        prefix_dirname.mkdir(parents=True,exist_ok=True)
+        prefix_dirname.mkdir(parents=True, exist_ok=True)
         for s in self.stations.name:
             self.acc2txt(s, prefix=prefix, title=prefix_filename, dt=dt)
 
@@ -870,24 +888,24 @@ class BBSeis:
 
     def all2txt(self, prefix="./", f="acc"):
         """
-        Produces outputs as if the HF binary produced individual text files.
-        For compatibility. Should run slices in parallel for performance.
-        Slowest part is numpy formating numbers into text and number of lines.
-        """
-        # prefix is assumed to have directory bit that ends with / and filename prefix
-        # if prefix ends with /, its prefix_filename is empty
-        # otherwise, prefix_filename is the last part of the prefix
-        # eg. prefix = "dir1/dir2/XXX", prefix_filename = "XXX" and prefix_dirname = "dir1/dir2"
-        # eg. prefix = "dir1/dir2/", prefix_filename = "" and prefix_dirname = "dir1/dir2"
+        Extracts waveform data from the binary file and produces output in text format.
 
-        prefix_chunks=prefix.split("/")
+        Parameters
+        ----------
+        prefix : str, optional, default="./"
+            The prefix is an output path combined with an optional filename prefix.
+            If prefix ends with /, its prefix_filename is empty, otherwise, prefix_filename is the last part of the prefix
+            eg. prefix = "dir1/dir2/XXX", prefix_filename = "XXX" and prefix_dirname = "dir1/dir2"
+            eg. prefix = "dir1/dir2/", prefix_filename = "" and prefix_dirname = "dir1/dir2"
+        f : str, optional
+            The type of data to save, by default "acc". Options are "acc" and "vel"
+        """
+        prefix_chunks = prefix.split("/")
         prefix_filename = prefix_chunks[-1]
         prefix_dirname = Path("/".join(prefix_chunks[:-1])).resolve()
-        prefix_dirname.mkdir(parents=True,exist_ok=True)
+        prefix_dirname.mkdir(parents=True, exist_ok=True)
         for s in self.stations.name:
             self.save_txt(s, prefix=prefix, title=prefix_filename, f=f)
-
-
 
     def save_ll(self, path):
         """

--- a/qcore/timeseries.py
+++ b/qcore/timeseries.py
@@ -502,10 +502,10 @@ class LFSeis:
         else:
             f = self.vel
         for i, c in enumerate(f(station, dt=dt).T):
-            seis2txt(
+            timeseries_to_text(
                 c,
+                f"{prefix}{station}.{self.COMP_NAME[i]}",
                 dt,
-                prefix,
                 station,
                 self.COMP_NAME[i],
                 start_sec=self.start_sec,
@@ -683,10 +683,10 @@ class HFSeis:
             dt = self.dt
         stat_idx = self.stat_idx[station]
         for i, c in enumerate(self.acc(station, dt=dt).T):
-            seis2txt(
+            timeseries_to_text(
                 c,
+                f"{prefix}{station}.{self.COMP_NAME[i]}",
                 dt,
-                prefix,
                 station,
                 self.COMP_NAME[i],
                 start_sec=self.start_sec,
@@ -758,7 +758,7 @@ class BBSeis:
         # read header - strings
         self.lf_dir, self.lf_vm, self.hf_file = np.fromfile(
             bbf, count=3, dtype="|S256"
-        ).astype(np.str_)
+        ).astype(np.unicode_)
 
         # load station info
         bbf.seek(self.HEAD_SIZE)
@@ -830,10 +830,10 @@ class BBSeis:
         xyz = []
         for i, c in enumerate(f(station).T):
             xyz.append(
-                seis2txt(
+                timeseries_to_text(
                     c,
-                    self.dt,
-                    prefix,
+                    f"{prefix}{station}.{self.COMP_NAME[i]}",
+                    dt,
                     station,
                     self.COMP_NAME[i],
                     start_sec=self.start_sec,


### PR DESCRIPTION
seis2txt() function was renamed to timeseries_to_text() with minor alterations (https://github.com/ucgmsim/qcore/pull/302/files), but we missed 3 places that still reference the old function name.

It was also noticed that the "prefix" parameter of `all2txt()` has a room for improvement. `prefix` can be a directory path plus a file name prefix. If the prefix ends with /, "file name prefix" part can be empty, and the entire prefix becomes the directory path.
If the prefix doesn't end with /, the last bit becomes the file name prefix, and the remaining part becomes the directory path. We don't handle these cases separately, or don't make sure the directory is available, so potentially the function call fails or writes files in an unexpected location with unintended file names.

I believe this PR resolves the issue.