### PR TITLE
Use find_packages to find packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 setup(
     name="qcore",
     version="1.2",
-    packages=["qcore"],
+    packages=["qcore", "qcore.uncertainties", "qcore.uncertainties.magnitude_scaling"],
     url="https://github.com/ucgmsim/qcore",
     description="QuakeCoRE Library",
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 import os
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 setup(
     name="qcore",
     version="1.2",
-    packages=["qcore", "qcore.uncertainties", "qcore.uncertainties.magnitude_scaling"],
+    packages=find_packages(),
     url="https://github.com/ucgmsim/qcore",
     description="QuakeCoRE Library",
     package_data={


### PR DESCRIPTION
This fixes the qcore installation. Currently, unless you install qcore as `pip install -e ...`, you cannot import `mag_scaling` from `qcore.uncertainties` because it isn't listed as a package in the setup.py. 