### PR TITLE
Changing order of (x, y, depth) in nztm_to_wgs_depth docstring for consistency

### DIFF
--- a/qcore/coordinates.py
+++ b/qcore/coordinates.py
@@ -75,7 +75,7 @@ def wgs_depth_to_nztm(wgs_depth_coordinates: np.ndarray) -> np.ndarray:
 
 def nztm_to_wgs_depth(nztm_coordinates: np.ndarray) -> np.ndarray:
     """
-    Convert NZTM coordinates (x, y, depth) to WGS84 coordinates.
+    Convert NZTM coordinates (y, x, depth) to WGS84 coordinates.
 
     Parameters
     ----------


### PR DESCRIPTION
This change will make the first line of the nztm_to_wgs_depth docstring consistent with what is (correctly) written later in the docstring:

```
    Parameters
    ----------
    nztm_coordinates : np.ndarray
        An array of shape (N, 3), (N, 2), (2,) or (3,) containing NZTM
        coordinates y, x and, optionally, depth.