### PR TITLE
Add the ability to compute point -> line segment distances

### DIFF
--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -1258,11 +1258,11 @@ def point_to_segment_distance(
     Parameters
     ----------
     p : npt.ArrayLike
-        The first point of the line segment.
+        A point to measure distance to.
     q : npt.ArrayLike
-        The second point of the line segment.
+        The first point of the line segment.
     r : npt.ArrayLike
-        A third point to measure distance to.
+        The second point of the line segment.
 
     Returns
     -------
@@ -1276,6 +1276,9 @@ def point_to_segment_distance(
 
     qr = r - q
     qp = p - q
+
+    if np.allclose(qr, 0):
+        raise ValueError("Degenerate line segment q -> r!")
 
     t = np.clip(np.dot(qp, qr) / np.dot(qr, qr), 0, 1)
 

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -1255,6 +1255,8 @@ def point_to_segment_distance(
 ) -> float:
     """Compute the shortest distance between a point and a line segment.
 
+    See [1] for a concise explanation of the calculations involved.
+
     Parameters
     ----------
     p : npt.ArrayLike
@@ -1269,6 +1271,10 @@ def point_to_segment_distance(
     float
         The distance between r and the closest point on the line
         segment pq to r.
+
+    References
+    ----------
+    [1]: https://math.stackexchange.com/questions/2193720/find-a-point-on-a-line-segment-which-is-the-closest-to-other-point-not-on-the-li/2193733#2193733
     """
     p = np.asarray(p)
     q = np.asarray(q)

--- a/qcore/geo.py
+++ b/qcore/geo.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from warnings import warn
 
 import numpy as np
+import numpy.typing as npt
 import scipy as sp
 
 from qcore.binary_version import get_unversioned_bin
@@ -1247,3 +1248,37 @@ def rotation_matrix(angle: float) -> np.ndarray:
         The 2x2 rotation matrix.
     """
     return np.array([[np.cos(angle), -np.sin(angle)], [np.sin(angle), np.cos(angle)]])
+
+
+def point_to_segment_distance(
+    p: npt.ArrayLike, q: npt.ArrayLike, r: npt.ArrayLike
+) -> float:
+    """Compute the shortest distance between a point and a line segment.
+
+    Parameters
+    ----------
+    p : npt.ArrayLike
+        The first point of the line segment.
+    q : npt.ArrayLike
+        The second point of the line segment.
+    r : npt.ArrayLike
+        A third point to measure distance to.
+
+    Returns
+    -------
+    float
+        The distance between r and the closest point on the line
+        segment pq to r.
+    """
+    p = np.asarray(p)
+    q = np.asarray(q)
+    r = np.asarray(r)
+
+    qr = r - q
+    qp = p - q
+
+    t = np.clip(np.dot(qp, qr) / np.dot(qr, qr), 0, 1)
+
+    closest_point = q + t * qr
+
+    return float(np.linalg.norm(p - closest_point))

--- a/qcore/test/test_geo/test_geo.py
+++ b/qcore/test/test_geo/test_geo.py
@@ -320,3 +320,33 @@ def test_closest_line_seg(l, m, l_closest_point, m_closest_point):
     (l_computed, m_computed) = geo.closest_points_between_line_segments(*l, *m)
     assert np.allclose(l_computed, l_closest_point)
     assert np.allclose(m_computed, m_closest_point)
+
+
+@pytest.mark.parametrize(
+    "p, q, r, expected_distance",
+    [
+        # Point lies on the segment
+        ([1, 0], [2, 0], [0, 0], 0.0),
+        # Point is off the segment, perpendicular distance
+        ([1, 1], [2, 0], [0, 0], 1.0),
+        # Point coincides with one endpoint
+        ([0, 0], [2, 0], [0, 0], 0.0),
+        # Closest point is one of the end points
+        ([3, 4], [2, 0], [0, 0], np.sqrt((3 - 2) ** 2 + 4**2)),
+        # Vertical segment
+        ([1, 1], [0, 2], [0, 0], 1.0),
+        # Horizontal segment
+        ([1, 1], [2, 0], [0, 0], 1.0),
+        # Diagonal segment
+        ([1, 0], [2, 2], [0, 0], np.sqrt(0.5)),
+    ],
+)
+def test_point_to_segment_distance(p, q, r, expected_distance):
+    """Test the point_to_segment_distance function with various cases."""
+    assert geo.point_to_segment_distance(p, q, r) == pytest.approx(expected_distance)
+
+
+def test_point_to_segement_degenerate():
+    """Test the failure case of a degenerate line."""
+    with pytest.raises(ValueError):
+        geo.point_to_segment_distance([1, 1], [0, 0], [0, 0])


### PR DESCRIPTION
Adds a new function `geo.point_to_segment_distance` which computes the closest distance between a point and a line segment. Required by https://github.com/ucgmsim/source_modelling/pull/13 for the rrup distance refactor.