### PR TITLE
Remove stations with an empty unicode name

### DIFF
--- a/qcore/timeseries.py
+++ b/qcore/timeseries.py
@@ -447,6 +447,9 @@ class LFSeis:
         # important to keep indexes correct, only remove empty items from end
         if stations.name[-1] == "":
             stations = stations[: -np.argmin((stations.name == "")[::-1])]
+        elif stations.name[-1] == b"":  # remove unicode empty strings
+            stations = stations[: -np.argmin((stations.name == b"")[::-1])]
+
         # store station names as unicode (python 3 strings)
         stat_type = stations.dtype.descr
         stat_type[6] = stat_type[6][0], "U7"

--- a/qcore/timeseries.py
+++ b/qcore/timeseries.py
@@ -445,10 +445,8 @@ class LFSeis:
         # protect against duplicated stations between processes
         # results in too many stations entries created, last ones are empty
         # important to keep indexes correct, only remove empty items from end
-        if stations.name[-1] == "":
-            stations = stations[: -np.argmin((stations.name == "")[::-1])]
-        elif stations.name[-1] == b"":  # remove unicode empty strings
-            stations = stations[: -np.argmin((stations.name == b"")[::-1])]
+        if stations.name[-1] in ["", b""]:
+            stations = stations[: -np.argmin((stations.name == stations.name[-1])[::-1])]
 
         # store station names as unicode (python 3 strings)
         stat_type = stations.dtype.descr


### PR DESCRIPTION
I noticed a considerable number of BB calculation failed due to inconsistent LF nstat and HF nstat

```
2024-12-12 19:07:11,855:rank_0:ERROR:LF nstat != HF nstat. 189 vs 96
```
This issue seemed related to the unusually many CPU cores for LF, which results in many "seis" files. The station information stored in all seis files need to be merged and cleaned up while an LFSeis object is created.

On closer inspection, nstat should be 96, but LFSeis has extra empty rows!!!

```
lf.stations =  rec.array([(219, 379, 1, [45,  0], -43.52025 , 172.58351, '274A'),
           (193, 378, 1, [45,  1], -43.487534, 172.53748, '275A'),
           (440, 396, 1, [53,  0], -43.808914, 172.96274, 'AKSS'),
           (126, 188, 1, [ 6,  0], -43.1537  , 172.72972, 'AMBC'),
           (130, 274, 1, [33,  0], -43.273087, 172.5948 , 'ASHS'),
           (233, 335, 1, [38,  0], -43.47853 , 172.68236, 'BWHS'),
           (189, 378, 1, [44,  0], -43.48271 , 172.53014, 'CACS'),
           (233, 372, 1, [45,  2], -43.527817, 172.62086, 'CBGS'),
...
           (  0,   0, 0, [ 0,  0],   0.      ,   0.     , ''),
           (  0,   0, 0, [ 0,  0],   0.      ,   0.     , ''),
           (  0,   0, 0, [ 0,  0],   0.      ,   0.     , ''),
           (  0,   0, 0, [ 0,  0],   0.      ,   0.     , ''),
           (  0,   0, 0, [ 0,  0],   0.      ,   0.     , ''),
           (  0,   0, 0, [ 0,  0],   0.      ,   0.     , ''),
           (  0,   0, 0, [ 0,  0],   0.      ,   0.     , ''),
           (  0,   0, 0, [ 0,  0],   0.      ,   0.     , ''),
           (  0,   0, 0, [ 0,  0],   0.      ,   0.     , '')],
          dtype=[('x', '<i4'), ('y', '<i4'), ('z', '<i4'), ('seis_idx', '<i4', (2,)), ('lat', '<f4'), ('lon', '<f4'), ('name', '<U7')])
```
If we remove the empty rows,  it leaves correct 96 stations.

The current code removes stations with an empty name, but it only checks ascii ""
```
           (148, 473, 1, [64,  1], -43.559357, 172.29657, b'SAND'),
           (165, 549, 1, [73,  1], -43.680756, 172.20049, b'SKTD'),
           (133, 513, 1, [69,  0], -43.594223, 172.2022 , b'TLED'),
           (  0,   0, 0, [ 0,  0],   0.      ,   0.     , b''),
           (  0,   0, 0, [ 0,  0],   0.      ,   0.     , b''),
           (  0,   0, 0, [ 0,  0],   0.      ,   0.     , b''),
...
```
We also need to check empty unicode names. 
