### PR TITLE
Add NZTM-compatible ellipsoid bearing calculations

### DIFF
--- a/qcore/coordinates.py
+++ b/qcore/coordinates.py
@@ -127,8 +127,15 @@ def bearing_between(point_a: np.ndarray, point_b: np.ndarray) -> float:
     Returns
     -------
     float
-        The bearing (in degrees) between point_a and point_b. Will return
-        an array of floats if input contains multiple points.
+        The bearing (in degrees) between point_a and point_b.
+
+    Examples
+    --------
+    >>> nztm_bearing_between(
+        np.array([-44.88388755, 166.8699418])
+        np.array([-42.73774027, 171.03176429])
+    )
+    55.999999966075194
     """
     fwd_azimuth, _, _ = _REF_ELLIPSOID.inv(
         point_a[1], point_a[0], point_b[1], point_b[0]
@@ -149,8 +156,15 @@ def nztm_bearing_between(point_a: np.ndarray, point_b: np.ndarray) -> float:
     Returns
     -------
     float
-            The bearing (in degrees) between point_a and point_b. Will return
-            an array of floats if input contains multiple points.
+        The bearing (in degrees) between point_a and point_b.
+
+    Examples
+    --------
+    >>> nztm_bearing_between(
+        np.array([5011637.39446645, 1115879.1174585 ]),
+        np.array([5266429.66487645, 1438889.1789583 ])
+    )
+    55.999999966075194
     """
     return bearing_between(nztm_to_wgs_depth(point_a), nztm_to_wgs_depth(point_b))
 
@@ -172,6 +186,15 @@ def forward_bearing(point_a: np.ndarray, bearing: float, distance: float) -> np.
     np.ndarray
         The new point (lat, lon) at the given bearing and distance from
         point_a.
+
+    Examples
+    --------
+    >>> forward_bearing(
+        np.array([-43.0, -172.0]),
+        45.0,
+        1000.0
+    )
+    array([-42.99363465, 172.0086709 ])
     """
     lon, lat, _ = _REF_ELLIPSOID.fwd(
         point_a[1], point_a[0], bearing, distance, radians=False
@@ -198,6 +221,15 @@ def nztm_forward_bearing(
     np.ndarray
             The new point (y, x) at the given bearing and distance from
             point_a.
+
+    Examples
+    --------
+    >>> forward_bearing(
+        array([5128644.8819868 , 2823486.41350085]),
+        45.0,
+        1000.0
+    )
+    array([5239415.32038242, 1519189.76925286])
     """
     return wgs_depth_to_nztm(
         forward_bearing(nztm_to_wgs_depth(point_a), bearing, distance)

--- a/qcore/coordinates.py
+++ b/qcore/coordinates.py
@@ -131,7 +131,7 @@ def bearing_between(point_a: np.ndarray, point_b: np.ndarray) -> float:
 
     Examples
     --------
-    >>> nztm_bearing_between(
+    >>> bearing_between(
         np.array([-44.88388755, 166.8699418])
         np.array([-42.73774027, 171.03176429])
     )
@@ -224,7 +224,7 @@ def nztm_forward_bearing(
 
     Examples
     --------
-    >>> forward_bearing(
+    >>> nztm_forward_bearing(
         array([5128644.8819868 , 2823486.41350085]),
         45.0,
         1000.0


### PR DESCRIPTION
This PR introduces four functions to the `coordinates` module.

- `forward_bearing` :: Advance a lat, lon coordinate in a given bearing direction by a given distance.
- `forward_bearing_nztm` :: As above but with nztm coordinates.
- `bearing_between` :: Find the bearing between two lat, lon coordinates.
- `bearing_between_nztm` :: As above but with nztm coordinates.

These are intended to replace the old NZTM bearing conversion for a couple of reasons:

1. Inaccuracies with these methods for very long fault planes.
2. Consistency with the [LINZ NZTM specification](https://www.linz.govt.nz/guidance/geodetic-system/coordinate-systems-used-new-zealand/projections/new-zealand-transverse-mercator-2000-nztm2000).

The functions are implemented with `pyproj` using the reference ellipsoid GRS80. This is the reference ellipsoid used to define the NZTM projection. In theory the ellipsoid differs from the WGS84 slightly due to rounding method but this is not a difference I can observe in my code. Note that both are technically incorrect because they can differ from the actual surface of the earth [by up to 100's of metres](https://www.linz.govt.nz/guidance/geodetic-system/coordinate-systems-used-new-zealand/projections/new-zealand-transverse-mercator-2000-nztm2000 "See section Geodetic Reference System 1980 (GRS80)").

## Why not `ll_bearing` and `ll_shift`?

These functions assume a spherical earth model. Which is fine. But it does differ from the bearings and coordinates returned by the GRS80 ellipsoid by a few kilometres. This might be significant depending on the application, so I opted to place these in the coordinates module to emphasise they were related to the coordinates and not replace the geo functions.

## Should I use `ll_bearing` and `ll_shift`

Depends on the application. On the small scale the differences between all these methods are trivial. You can observe kilometre-scale differences at the Alpine-fault level. Somewhere between these scales and depending on tolerance for uncertainty a switch becomes appropriate.