### PR TITLE
Add kwargs to from_docstring decorator

### DIFF
--- a/qcore/cli.py
+++ b/qcore/cli.py
@@ -12,13 +12,15 @@ from docstring_parser.common import DocstringStyle
 
 # Originally written by @Genfood: https://github.com/fastapi/typer/issues/336#issuecomment-2434726193
 # Updated and modified for Python 3.13.
-def from_docstring(app: typer.Typer) -> Callable:
+def from_docstring(app: typer.Typer, **kwargs: dict) -> Callable:
     """Apply help texts from the function's docstring to Typer arguments/options and command.
 
     Parameters
     ----------
     app : typer.Typer
         The Typer application to which the command will be registered.
+    **kwargs : dict
+        Additional keyword arguments to be passed to the Typer command.
 
     Returns
     -------
@@ -104,7 +106,7 @@ def from_docstring(app: typer.Typer) -> Callable:
         # Apply the new signature to the wrapper function
 
         # Register the command with the app
-        @app.command(help=command_help.strip())
+        @app.command(help=command_help.strip(), **kwargs)
         @wraps(command)
         def wrapper(*args: Any, **kwargs: Any) -> Any:  # numpydoc ignore=GL08
             return command(*args, **kwargs)

--- a/qcore/test/test_cli/test_cli.py
+++ b/qcore/test/test_cli/test_cli.py
@@ -1,10 +1,10 @@
+from typing import Annotated, Optional
+
+import pytest
 import typer
 from typer.testing import CliRunner
-from typing import Annotated, Optional
-import pytest
 
 from qcore import cli
-import pytest
 
 runner = CliRunner()
 
@@ -51,6 +51,70 @@ def test_from_docstring(capsys: pytest.CaptureFixture[str]):
     assert "This is an optional parameter." in result.output
     result = runner.invoke(app, ["0", "--param2", "b"])
     assert result.stdout.strip() == "Hello World 0 b"
+
+    example_command(1, "c")
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "Hello World 1 c"
+
+
+def test_from_docstring_kwargs(capsys: pytest.CaptureFixture[str]):
+    """Test the from_docstring decorator passes kwargs correctly."""
+
+    app = typer.Typer()
+
+    @cli.from_docstring(app, name="command_1")
+    def example_command(
+        param1: Annotated[int, typer.Argument()],
+        param2: Annotated[Optional[str], typer.Option()] = "a",
+    ) -> None:
+        """Example command.
+
+        Parameters
+        ----------
+        param1 : int
+            This is the first parameter.
+        param2 : Optional[str]
+            This is an optional parameter.
+        """
+        print("Hello World", param1, param2)
+
+    @cli.from_docstring(app, name="command_2")
+    def example_command_2(
+        param1: Annotated[int, typer.Argument()],
+        param2: Annotated[Optional[str], typer.Option()] = "b",
+    ) -> None:
+        """Example command 2.
+
+        Parameters
+        ----------
+        param1 : int
+            This is the first parameter of command 2.
+        param2 : Optional[str]
+            This is an optional parameter for command 2.
+        """
+        print("Hello World from command 2", param1, param2)
+
+    # Ensure the docstring is unchanged
+    assert example_command.__doc__ == DOCSTRING
+    # Run `--help` and check output
+
+    result = runner.invoke(app, ["command_1", "--help"])
+    assert result.exit_code == 0
+    assert "Example command." in result.output
+    assert "This is the first parameter." in result.output
+    assert "This is an optional parameter." in result.output
+
+    result = runner.invoke(app, ["command_2", "--help"])
+    assert result.exit_code == 0
+    assert "Example command 2." in result.output
+    assert "This is the first parameter of command 2." in result.output
+    assert "This is an optional parameter for command 2." in result.output
+
+    result = runner.invoke(app, ["command_1", "0", "--param2", "b"])
+    assert result.stdout.strip() == "Hello World 0 b"
+
+    result = runner.invoke(app, ["command_2", "0", "--param2", "b"])
+    assert result.stdout.strip() == "Hello World from command 2 0 b"
 
     example_command(1, "c")
     captured = capsys.readouterr()


### PR DESCRIPTION
Adds a `**kwargs` parameter to `cli.from_docstring` so that you can do things like customising the name of docstring extracted commands:

``` python
from typing import Annotated, Optional

import typer

from qcore import cli

app = typer.Typer()


@cli.from_docstring(app, name="command_1")
def example_command(
    param1: Annotated[int, typer.Argument()],
    param2: Annotated[Optional[str], typer.Option()] = "a",
) -> None:
    """Example command.

    Parameters
    ----------
    param1 : int
        This is the first parameter.
    param2 : Optional[str]
        This is an optional parameter.
    """
    print("Hello World", param1, param2)


@cli.from_docstring(app, name="command_2")
def example_command_2(
    param1: Annotated[int, typer.Argument()],
    param2: Annotated[Optional[str], typer.Option()] = "b",
) -> None:
    """Example command 2.

    Parameters
    ----------
    param1 : int
        This is the first parameter of command 2.
    param2 : Optional[str]
        This is an optional parameter for command 2.
    """
    print("Hello World from command 2", param1, param2)
```